### PR TITLE
Tiny fixes for some files

### DIFF
--- a/xmcl-keystone-ui/src/components/StepServer.vue
+++ b/xmcl-keystone-ui/src/components/StepServer.vue
@@ -105,7 +105,7 @@
                   <v-icon left>
                     wifi
                   </v-icon>
-                  {{ t('server.ping') }}
+                  {{ t('refresh') }}
                 </v-btn>
               </div>
             </div>

--- a/xmcl-keystone-ui/src/views/HomeModCard.vue
+++ b/xmcl-keystone-ui/src/views/HomeModCard.vue
@@ -1,7 +1,7 @@
 <template>
   <HomeCard
-    title="Mod"
     icon="extension"
+    :title="t('mod.name', 2)"
     :text="t('mod.enabled', { count: enabledModCounts })"
     :icons="icons"
     :refreshing="isValidating"


### PR DESCRIPTION
1. Fix hardcoded title in `HomeModCard.vue`
   Nothing special
2. Change button name from `Ping` to `Refresh`
   #### Why?
   In some languages, like Russian and Ukrainian, the word "ping" literally means "ping", but it doesn't have the "action" context as it does in English and some other languages.

   If we change the button name to "Refresh", the meaning will remain the same for English and other languages, while it will make sense for languages like Russian and Ukrainian.
