### PR TITLE
fix: modpack marketplace search bar color

### DIFF
--- a/xmcl-keystone-ui/src/views/StoreEntry.vue
+++ b/xmcl-keystone-ui/src/views/StoreEntry.vue
@@ -18,7 +18,6 @@
         id="search-text-field"
         ref="searchTextField"
         v-model="keyword"
-        background-color="secondary"
         color="green"
         class="rounded-xl search-field pr-4"
         append-icon="search"


### PR DESCRIPTION
removed background color setting of modpack marketplace search bar(this fixes the background color in light mode)

![image](https://github.com/user-attachments/assets/da9e82d0-32eb-4f4e-8106-15b25fb229a3)

And dark mode search bar is also changed as before(the window which is at back is the fixed version):

![image](https://github.com/user-attachments/assets/5830fb72-f036-40a7-99ba-37d68c17ef8b)