### PR TITLE
fix: remove limit for event emitters for listeners

### DIFF
--- a/xmcl-electron-app/main/index.ts
+++ b/xmcl-electron-app/main/index.ts
@@ -3,5 +3,9 @@ require('graceful-fs').gracefulify(require('fs'))
 
 // eslint-disable-next-line import/first
 import ElectronLauncherApp from './ElectronLauncherApp'
+// eslint-disable-next-line import/first
+import { EventEmitter } from 'events'
+
+EventEmitter.setMaxListeners(0)
 
 new ElectronLauncherApp().start()


### PR DESCRIPTION
I found EventEmitter's max listener limit seems making some event listeners to ignore the events.
~~And it seems it's causing infinite blocking issue in #838~~ it didn't fix
![image](https://github.com/user-attachments/assets/e51aa552-5003-4ba1-b54e-71011b169f7c)
