### PR TITLE
docs: add homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ winget install CI010.XMinecraftLauncher
 HomeBrew installation also available via tap
 
 ```bash
-brew tap sylvanfranklin/xmcl
-brew install --cask --no-quarantine sylvanfranklin/xmcl
+brew tap voxelum/xmcl
+brew install --cask --no-quarantine voxelum/xmcl
 ```
 
 <kbd>[<img title="Ukraine" alt="Ukraine" src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Flag_of_Ukraine.svg/1280px-Flag_of_Ukraine.svg.png" width="22">](docs/README.uk.md)</kbd>

--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ If you have winget, you can use winget to install
 winget install CI010.XMinecraftLauncher
 ```
 
+HomeBrew installation also available via tap
+
+```bash
+brew tap sylvanfranklin/xmcl
+brew install --cask --no-quarantine sylvanfranklin/xmcl
+```
+
 <kbd>[<img title="Ukraine" alt="Ukraine" src="https://upload.wikimedia.org/wikipedia/commons/thumb/4/49/Flag_of_Ukraine.svg/1280px-Flag_of_Ukraine.svg.png" width="22">](docs/README.uk.md)</kbd>
 <kbd>[<img title="Russia" alt="Russia" src="https://upload.wikimedia.org/wikipedia/commons/thumb/f/f3/Flag_of_Russia.svg/1280px-Flag_of_Russia.svg.png" width="22">](docs/README.ru.md)</kbd>
 <kbd>[<img title="Germany" alt="Germany" src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/ba/Flag_of_Germany.svg/2560px-Flag_of_Germany.svg.png" width="22">](docs/README.de.md)</kbd>


### PR DESCRIPTION
Added instructions for homebrew tap that bypasses code signing by disabling quarantine. I don't know if you want the instructions in the main part of the README or somewhere else but this seems suitable. 