### PR TITLE
feat: Add no Cyrillic characters validation for instance name

### DIFF
--- a/xmcl-keystone-ui/locales/de.yaml
+++ b/xmcl-keystone-ui/locales/de.yaml
@@ -538,6 +538,7 @@ instance:
   mcOptionsHint: Zusätzliche Anweisungen zum Starten von Minecraft
   name: Profilname
   nameHint: Der Name, der zur Identifizierung des Spiels verwendet wird
+  nameNoCyrillic: Der Name darf keine kyrillischen Zeichen enthalten
   neverPlayed: Nie gespielt
   openCrashReportFolder: Öffnen Sie den Ordner mit den Absturzberichten
   openLogFolder: Öffnen Sie den Ordner logs

--- a/xmcl-keystone-ui/locales/en.yaml
+++ b/xmcl-keystone-ui/locales/en.yaml
@@ -483,6 +483,7 @@ instance:
   mcOptionsHint: Additional Minecraft launch arguments
   name: Profile Name
   nameHint: The name of the modpack
+  nameNoCyrillic: The name cannot contain Cyrillic characters
   neverPlayed: Never Played
   openCrashReportFolder: Open Crash Report Folder
   openLogFolder: Open Log Folder

--- a/xmcl-keystone-ui/locales/es-ES.yaml
+++ b/xmcl-keystone-ui/locales/es-ES.yaml
@@ -413,6 +413,7 @@ instance:
   mcOptionsHint: Argumentos adicionales de lanzamiento de Minecraft
   name: Nombre del Perfil
   nameHint: El nombre utilizado para identificar el juego
+  nameNoCyrillic: El nombre de la instancia no puede contener caracteres cirílicos
   neverPlayed: Nunca Jugado
   openCrashReportFolder: Abrir Carpeta de Informes de Errores
   openLogFolder: Abrir Carpeta de Registro

--- a/xmcl-keystone-ui/locales/fr.yaml
+++ b/xmcl-keystone-ui/locales/fr.yaml
@@ -493,6 +493,7 @@ instance:
   mcOptionsHint: Arguments supplémentaires pour le lancement de Minecraft
   name: Nom de profil
   nameHint: Le nom utilisé pour identifier le jeu
+  nameNoCyrillic: Le nom ne doit pas contenir de caractères cyrilliques
   neverPlayed: Jamais Joué
   openCrashReportFolder: Ouvrir le dossier de rapport de crash
   openLogFolder: Ouvrir le dossier de logs

--- a/xmcl-keystone-ui/locales/hu.yaml
+++ b/xmcl-keystone-ui/locales/hu.yaml
@@ -456,6 +456,7 @@ instance:
   mcOptionsHint: Kiegészítő Minecraft indítási beállítások
   name: Profil név
   nameHint: A játék azonosítására használt név
+  nameNoCyrillic: A név nem tartalmazhat cirill karaktereket
   neverPlayed: Soha nem játszott
   openCrashReportFolder: Összeomlási jelentések mapppa megnyitása
   openLogFolder: Napló mappa megnyitása

--- a/xmcl-keystone-ui/locales/it-IT.yaml
+++ b/xmcl-keystone-ui/locales/it-IT.yaml
@@ -466,6 +466,7 @@ instance:
   mcOptionsHint: Argomenti di avvio aggiuntivi di Minecraft
   name: Nome profilo
   nameHint: Il nome utilizzato per identificare il gioco
+  nameNoCyrillic: Il nome non può contenere caratteri cirillici
   neverPlayed: Mai giocato
   openCrashReportFolder: Apri la cartella del report di arresto anomalo
   openLogFolder: Apri la cartella dei log

--- a/xmcl-keystone-ui/locales/ja-JP.yaml
+++ b/xmcl-keystone-ui/locales/ja-JP.yaml
@@ -440,6 +440,7 @@ instance:
   mcOptionsHint: 追加のMinecraft実行引数
   name: 起動構成の名前
   nameHint: Modpackの名前
+  nameNoCyrillic: キリル文字は使用できません
   neverPlayed: 未プレイ
   openCrashReportFolder: クラッシュレポートフォルダを開く
   openLogFolder: ログフォルダを開く

--- a/xmcl-keystone-ui/locales/lolcat.yaml
+++ b/xmcl-keystone-ui/locales/lolcat.yaml
@@ -429,6 +429,7 @@ instance:
   mcOptionsHint: ADDISHUNAL MINECRAFT LAUNCH ARGUMENTS
   name: PROFILE NAYM
   nameHint: TEH NAYM OV TEH MODPACK
+  nameNoCyrillic: NO CYRILLIC CHARACTERZ ALLOWD
   neverPlayed: NEVR PLAYD
   openCrashReportFolder: OPEN CRASH REPORT FOLDR
   openLogFolder: OPEN LOG FOLDR

--- a/xmcl-keystone-ui/locales/pl.yaml
+++ b/xmcl-keystone-ui/locales/pl.yaml
@@ -460,6 +460,7 @@ instance:
   mcOptionsHint: Dodatkowe poprawki dotyczące uruchomienia gry Minecraft
   name: Nazwa profilu
   nameHint: Nazwa używana do identyfikacji gry
+  nameNoCyrillic: Nazwa (bez znaków cyrylicy)
   neverPlayed: Nigdy nie grał
   openCrashReportFolder: Otwórz folder raportów o wypadkach
   openLogFolder: Otwórz folder dziennika

--- a/xmcl-keystone-ui/locales/pt-BR.yaml
+++ b/xmcl-keystone-ui/locales/pt-BR.yaml
@@ -504,6 +504,7 @@ instance:
   mcOptionsHint: Argumentos adicionais para o lançamento do Minecraft
   name: Nome do Perfil
   nameHint: O nome do modpack
+  nameNoCyrillic: O nome não deve conter caracteres cirílicos
   neverPlayed: Nunca Jogado
   openCrashReportFolder: Abrir a pasta de relatórios de erro
   openLogFolder: Abrir a pasta de logs

--- a/xmcl-keystone-ui/locales/ru.yaml
+++ b/xmcl-keystone-ui/locales/ru.yaml
@@ -495,6 +495,7 @@ instance:
   mcOptionsHint: Дополнительные аргументы запуска Minecraft
   name: Имя экземпляра
   nameHint: Имя, используемое для идентификации экземпляра.
+  nameNoCyrillic: Название не может содержать кириллические символы
   neverPlayed: Никогда не играли
   openCrashReportFolder: Открыть папку с отчётами об ошибках
   openLogFolder: Открыть папку с журналами

--- a/xmcl-keystone-ui/locales/uk.yaml
+++ b/xmcl-keystone-ui/locales/uk.yaml
@@ -494,6 +494,7 @@ instance:
   mcOptionsHint: Додаткові аргументи запуску Minecraft
   name: Назва профілю
   nameHint: Назва модпаку
+  nameNoCyrillic: Назва повинна бути без кирилиці
   neverPlayed: Ніколи не грав
   openCrashReportFolder: Відкрити папку звітів про збої
   openLogFolder: Відкрити папку логів

--- a/xmcl-keystone-ui/locales/zh-CN.yaml
+++ b/xmcl-keystone-ui/locales/zh-CN.yaml
@@ -454,6 +454,7 @@ instance:
   mcOptionsHint: 额外的 Minecraft 启动参数
   name: 名称
   nameHint: 名称便于以后识别
+  nameNoCyrillic: 无西里尔字母名称
   neverPlayed: 从未游玩
   openCrashReportFolder: 打开包含错误报告的文件夹
   openLogFolder: 打开日志文件夹

--- a/xmcl-keystone-ui/locales/zh-TW.yaml
+++ b/xmcl-keystone-ui/locales/zh-TW.yaml
@@ -455,6 +455,7 @@ instance:
   mcOptionsHint: 額外的 Minecraft 啟動引數
   name: 名稱
   nameHint: 名稱便於以後識別
+  nameNoCyrillic: 名稱不應包含西里爾字母
   neverPlayed: 從未遊玩
   openCrashReportFolder: 開啟當機報告資料夾
   openLogFolder: 開啟日誌資料夾

--- a/xmcl-keystone-ui/src/components/StepConfig.vue
+++ b/xmcl-keystone-ui/src/components/StepConfig.vue
@@ -96,6 +96,7 @@ const { instances } = injection(kInstances)
 const nameRules = computed(() => [
   (v: any) => !!v || t('instance.requireName'),
   (v: any) => !instances.value.some(i => i.name === v.trim()) || t('instance.duplicatedName'),
+  (v: any) => !/\p{Script=Cyrillic}/u.test(v) || t('instance.nameNoCyrillic'),
 ])
 
 const scrollElement = ref<HTMLElement | null>(null)

--- a/xmcl-keystone-ui/src/views/InstancesCreateButton.vue
+++ b/xmcl-keystone-ui/src/views/InstancesCreateButton.vue
@@ -1,6 +1,6 @@
 <template>
   <v-btn
-    v-shared-tooltip="_ => t('instances.add')"
+    v-shared-tooltip="(_: HTMLElement) => t('instances.add')"
     text
     @click="showAddInstanceDialog()"
   >


### PR DESCRIPTION
Many people who use the launcher create modpacks in another language (Ukrainian, Russian, etc.) This PR adds a correction and prohibits creating modpacks with the following names

![image](https://github.com/user-attachments/assets/a72ad636-00bc-4389-addb-86ef6f827994)
