### PR TITLE
fix(ui): prevent launch button badge/icon from being clipped

### DIFF
--- a/xmcl-keystone-ui/src/views/HomeExtension.vue
+++ b/xmcl-keystone-ui/src/views/HomeExtension.vue
@@ -44,7 +44,7 @@
     <transition name="fade-transition">
       <div
         key="launch-button-group"
-        class="flex items-center justify-end overflow-hidden"
+        class="flex items-center justify-end overflow-visible"
         v-if="!isInFocusMode || !(router.currentRoute.path === '/')"
       >
         <HomeHeaderInstallStatus


### PR DESCRIPTION
<img width="1919" height="1079" alt="스크린샷 2025-09-17 204226" src="https://github.com/user-attachments/assets/d799be06-9946-400d-bf8c-9255112f63ec" />

The one below is before the revision, and the one above is after the revision.

I don't know what this feature does, but it looked strange, so I fixed it.