### PR TITLE
feat: added mouse drag to scroll on UserCard cape selection 

### DIFF
--- a/xmcl-keystone-ui/src/components/UserCardMicrosoft.vue
+++ b/xmcl-keystone-ui/src/components/UserCardMicrosoft.vue
@@ -67,10 +67,15 @@
           </v-list-item>
 
           <v-slide-group
+            ref="slideGroupRef"
             v-model="capeModel"
             mandatory
             show-arrows
-            class="max-w-[400px] overflow-x-auto"
+            class="max-w-[400px] select-none cursor-grab active:cursor-grabbing"
+            @mousedown.native="onDragStart"
+            @mousemove.native="onDragMove"
+            @mouseup.native="onDragEnd"
+            @mouseleave.native="onDragEnd"
           >
             <v-slide-item
               v-slot="{ active, toggle }"
@@ -180,6 +185,39 @@ const capeModel = computed({
     }
   },
 })
+const slideGroupRef = ref<any>(null)
+let isDragging = false
+let startX = 0
+let startScrollOffset = 0
+
+const onDragStart = (e: MouseEvent) => 
+{
+  const sg = slideGroupRef.value
+  if (!sg) return
+  isDragging = true
+  startX = e.pageX
+  startScrollOffset = sg.scrollOffset
+  sg.$refs.content?.style.setProperty('transition', 'none')
+  sg.$refs.content?.style.setProperty('willChange', 'transform')
+}
+
+const onDragMove = (e: MouseEvent) => 
+{
+  if (!isDragging) return
+  e.preventDefault()
+  slideGroupRef.value.scrollOffset = startScrollOffset + (startX - e.pageX)
+}
+
+const onDragEnd = () => 
+{
+  if (!isDragging) return
+  isDragging = false
+  const sg = slideGroupRef.value
+  sg.$refs.content?.style.setProperty('transition', null)
+  sg.$refs.content?.style.setProperty('willChange', null)
+  const max = sg.$refs.content.clientWidth - sg.$refs.wrapper.clientWidth
+  sg.scrollOffset = Math.max(0, Math.min(sg.scrollOffset, max))
+}
 
 const currentCape = computed(() => capes.value.find(v => v.state === 'ACTIVE'))
 const { checkNameAvailability, setName } = useService(OfficialUserServiceKey)


### PR DESCRIPTION
Added drag to scroll interaction to cape selection `v-slide-group` in UserCardMicrosoft component. I was using xmcl and then tried to do it myself but it didn't work so I just had to implement it myself.

I added: 
1. listeners to `v-slide-group` like mousedown, mousemove, mouseup and mouseleave.
2. Edited Vuetify internal scrollOffset prop to mimic a touch handler logic.
3. Disabled some CSS transitions during drag to make it smoother, reenabled on mouse release.

Just a UI only change.

### Before
<img width="560" height="653.6" alt="image" src="https://github.com/user-attachments/assets/9da51ec6-ba9d-49b2-a9cf-ff3028f78055" />

### After
<img width="560" height="653.6" alt="image" src="https://github.com/user-attachments/assets/7f2e4bf8-2a02-40c3-83f9-4d67b72d38ae" />
