### PR TITLE
fix: Shader pack Unicode display & disable deleting file

### DIFF
--- a/xmcl-keystone-ui/src/views/ShaderPack.vue
+++ b/xmcl-keystone-ui/src/views/ShaderPack.vue
@@ -60,7 +60,7 @@
         :curseforge="selectedItem?.curseforge?.id || selectedItem?.curseforgeProjectId"
         @uninstall="onUninstall"
         @enable="onEnable"
-        @disable="onUninstall([$event])"
+        @disable="onDisable"
         @category="toggleCategory"
       />
       <MarketProjectDetailCurseforge
@@ -74,7 +74,7 @@
         :modrinth="selectedModrinthId"
         @uninstall="onUninstall"
         @enable="onEnable"
-        @disable="onUninstall([$event])"
+        @disable="onDisable"
         @category="curseforgeCategory = $event"
       />
       <ShaderPackDetailResource
@@ -362,6 +362,9 @@ const { shaderPack } = injection(kInstanceShaderPacks)
 const onUninstall = (files: ProjectFile[]) => {
   shaderPack.value = ''
   uninstall({ path: path.value, files: files.map(f => f.path) })
+}
+const onDisable = () => {
+  shaderPack.value = ''
 }
 const onEnable = async (f: ProjectFile | string) => {
   if (!shaderMod.value && !runtime.value.optifine) {

--- a/xmcl-runtime-api/src/entities/shaderpack.test.ts
+++ b/xmcl-runtime-api/src/entities/shaderpack.test.ts
@@ -1,0 +1,134 @@
+import { describe, test, expect } from 'vitest'
+import { parseShaderOptions, stringifyShaderOptions } from './shaderpack'
+
+describe('parseShaderOptions', () => {
+  test('should parse basic shader options', () => {
+    const text = 'shaderPack=BSL_v8.2.01.zip\n'
+    const result = parseShaderOptions(text)
+    expect(result.shaderPack).toEqual('BSL_v8.2.01.zip')
+  })
+
+  test('should decode unicode escapes in shaderPack name', () => {
+    // "补全光影" encoded as unicode escapes
+    const text = 'shaderPack=\\u8865\\u5168\\u5149\\u5f71.zip\n'
+    const result = parseShaderOptions(text)
+    expect(result.shaderPack).toEqual('补全光影.zip')
+  })
+
+  test('should decode mixed ASCII and unicode escapes', () => {
+    const text = 'shaderPack=BSL \\u5149\\u5f71\\u5305 v8.zip\n'
+    const result = parseShaderOptions(text)
+    expect(result.shaderPack).toEqual('BSL 光影包 v8.zip')
+  })
+
+  test('should default to empty string if shaderPack is missing', () => {
+    const text = 'oldLighting=false\n'
+    const result = parseShaderOptions(text)
+    expect(result.shaderPack).toEqual('')
+  })
+
+  test('should parse multiple options', () => {
+    const text = [
+      'shaderPack=SEUS-Renewed-v1.0.1.zip',
+      'antialiasingLevel=0',
+      'normalMapEnabled=true',
+      'specularMapEnabled=true',
+      'renderResMul=1.0',
+      'shadowResMul=1.0',
+      'handDepthMul=0.125',
+      'oldLighting=default',
+      '',
+    ].join('\n')
+    const result = parseShaderOptions(text)
+    expect(result.shaderPack).toEqual('SEUS-Renewed-v1.0.1.zip')
+  })
+
+  test('should skip comment lines', () => {
+    const text = '#This is a comment\nshaderPack=test.zip\n'
+    const result = parseShaderOptions(text)
+    expect(result.shaderPack).toEqual('test.zip')
+  })
+
+  test('should skip empty lines', () => {
+    const text = '\n\nshaderPack=test.zip\n\n'
+    const result = parseShaderOptions(text)
+    expect(result.shaderPack).toEqual('test.zip')
+  })
+
+  test('should decode Japanese shader pack name', () => {
+    // シェーダー = "shader" in Japanese
+    const text = 'shaderPack=\\u30b7\\u30a7\\u30fc\\u30c0\\u30fc.zip\n'
+    const result = parseShaderOptions(text)
+    expect(result.shaderPack).toEqual('シェーダー.zip')
+  })
+})
+
+describe('stringifyShaderOptions', () => {
+  test('should stringify basic options', () => {
+    const options = { shaderPack: 'BSL_v8.zip' }
+    const result = stringifyShaderOptions(options)
+    expect(result).toEqual('shaderPack=BSL_v8.zip\n')
+  })
+
+  test('should encode non-ASCII characters to unicode escapes', () => {
+    const options = { shaderPack: '补全光影.zip' }
+    const result = stringifyShaderOptions(options)
+    expect(result).toContain('shaderPack=\\u8865\\u5168\\u5149\\u5f71.zip')
+    expect(result).not.toContain('补全光影')
+  })
+
+  test('should encode mixed ASCII and non-ASCII', () => {
+    const options = { shaderPack: 'BSL 光影包.zip' }
+    const result = stringifyShaderOptions(options)
+    expect(result).toContain('shaderPack=BSL \\u5149\\u5f71\\u5305.zip')
+  })
+
+  test('should end with newline', () => {
+    const options = { shaderPack: 'test.zip' }
+    const result = stringifyShaderOptions(options)
+    expect(result.endsWith('\n')).toBe(true)
+  })
+
+  test('should handle empty shaderPack', () => {
+    const options = { shaderPack: '' }
+    const result = stringifyShaderOptions(options)
+    expect(result).toEqual('shaderPack=\n')
+  })
+})
+
+describe('shaderOptions unicode roundtrip', () => {
+  test('should roundtrip ASCII shader pack name', () => {
+    const original = { shaderPack: 'SEUS-Renewed-v1.0.1.zip' }
+    const text = stringifyShaderOptions(original)
+    const parsed = parseShaderOptions(text)
+    expect(parsed.shaderPack).toEqual(original.shaderPack)
+  })
+
+  test('should roundtrip Chinese shader pack name', () => {
+    const original = { shaderPack: '补全光影 - 高性能版.zip' }
+    const text = stringifyShaderOptions(original)
+    const parsed = parseShaderOptions(text)
+    expect(parsed.shaderPack).toEqual(original.shaderPack)
+  })
+
+  test('should roundtrip mixed content shader pack name', () => {
+    const original = { shaderPack: 'BSL Shaders v8.2 - 光影包测试.zip' }
+    const text = stringifyShaderOptions(original)
+    const parsed = parseShaderOptions(text)
+    expect(parsed.shaderPack).toEqual(original.shaderPack)
+  })
+
+  test('should roundtrip multiple options with unicode values', () => {
+    const original = {
+      shaderPack: '高清光影.zip',
+      oldLighting: 'default',
+    } as any
+    const text = stringifyShaderOptions(original)
+    // Verify encoded text doesn't contain raw Chinese
+    expect(text).not.toContain('高清光影')
+    expect(text).toContain('\\u')
+    // Verify roundtrip
+    const parsed = parseShaderOptions(text)
+    expect(parsed.shaderPack).toEqual('高清光影.zip')
+  })
+})

--- a/xmcl-runtime-api/src/entities/shaderpack.ts
+++ b/xmcl-runtime-api/src/entities/shaderpack.ts
@@ -1,3 +1,5 @@
+import { decodeUnicodeEscapes, encodeUnicodeEscapes } from '@xmcl/gamesetting'
+
 export interface ShaderPack {
 
 }
@@ -7,7 +9,7 @@ export interface ShaderOptions {
 }
 
 export function parseShaderOptions(text: string): ShaderOptions {
-  const options = text.split('\n').map(s => s.trim()).filter(l => l.length !== 0 && !l.startsWith('#')).map(s => s.split('=')).reduce((a, b) => Object.assign(a, { [b[0]]: b[1] }), {}) as Record<string, string>
+  const options = text.split('\n').map(s => s.trim()).filter(l => l.length !== 0 && !l.startsWith('#')).map(s => s.split('=')).reduce((a, b) => Object.assign(a, { [b[0]]: decodeUnicodeEscapes(b[1]) }), {}) as Record<string, string>
   if (!options.shaderPack) {
     options.shaderPack = ''
   }
@@ -15,5 +17,5 @@ export function parseShaderOptions(text: string): ShaderOptions {
 }
 
 export function stringifyShaderOptions(options: ShaderOptions): string {
-  return Object.entries(options).map(([k, v]) => `${k}=${v}`).join('\n') + '\n'
+  return Object.entries(options).map(([k, v]) => `${k}=${encodeUnicodeEscapes(v)}`).join('\n') + '\n'
 }

--- a/xmcl-runtime/instance/InstanceOptionsService.ts
+++ b/xmcl-runtime/instance/InstanceOptionsService.ts
@@ -1,4 +1,4 @@
-import { type Frame, parse } from '@xmcl/gamesetting'
+import { type Frame, parse, encodeUnicodeEscapes, decodeUnicodeEscapes } from '@xmcl/gamesetting'
 import {
   type EditGameSettingOptions,
   type EditShaderOptions,
@@ -23,6 +23,7 @@ import {
   missing,
   unHardLinkFiles,
 } from '../util/fs'
+
 import { requireString } from '../util/object'
 import { existsSync } from 'fs'
 
@@ -250,7 +251,7 @@ export class InstanceOptionsService extends AbstractService implements IInstance
       configFile,
       Object.entries(current)
         .filter(([k, v]) => !!k && !!v)
-        .map(([k, v]) => `${k}=${v}`)
+        .map(([k, v]) => `${k}=${encodeUnicodeEscapes(v)}`)
         .join('\n') + '\n',
     )
   }
@@ -267,6 +268,12 @@ export class InstanceOptionsService extends AbstractService implements IInstance
       string,
       string
     >
+    // Decode Java-style unicode escape sequences
+    for (const key of Object.keys(options)) {
+      if (typeof options[key] === 'string') {
+        options[key] = decodeUnicodeEscapes(options[key])
+      }
+    }
     return options
   }
 

--- a/xmcl-runtime/instance/InstanceOptionsService.ts
+++ b/xmcl-runtime/instance/InstanceOptionsService.ts
@@ -245,6 +245,7 @@ export class InstanceOptionsService extends AbstractService implements IInstance
   async #editShaderOptions(pack: string, instancePath: string, name: string) {
     const current = await this.#getProperties(instancePath, name)
     current.shaderPack = pack
+    current.enableShaders = pack ? 'true' : 'false'
     const configFile = join(instancePath, 'config', name)
     await ensureDir(join(instancePath, 'config'))
     await writeFile(


### PR DESCRIPTION
 ## Summary
 
 Fix two shader pack related issues:
 
 ### 1. Non-ASCII shader pack names display as raw Unicode escapes
 
 Minecraft stores non-ASCII characters (e.g. Chinese) as Java-style `\uXXXX` escape sequences in `optionsshaders.txt`, `iris.properties`, and `oculus.properties`. The launcher was displaying the raw escape sequences
 
 **Changes:**
 - Export `decodeUnicodeEscapes` / `encodeUnicodeEscapes` utilities from `@xmcl/gamesetting` for reuse
 - Decode `\uXXXX` sequences when reading shader options (optionsshaders.txt, iris.properties, oculus.properties)
 - Encode non-ASCII characters back to `\uXXXX` when writing, so Minecraft can still read them
 
 ### 2. Disabling a shader pack deletes the shader pack file
 
 The `@disable` event in ShaderPack.vue was incorrectly bound to `onUninstall`, which both clears the config **and** deletes the shader pack zip file. Disabling should only modify the config file.
 
 **Changes:**
 - Add separate `onDisable` handler that only sets `shaderPack = ''` without file deletion
 - Set `enableShaders=true/false` in iris/oculus properties when enabling/disabling shader packs