### PR TITLE
fix: validate instance name for filesystem safety and fix false duplicate detection

### DIFF
--- a/xmcl-keystone-ui/locales/en.yaml
+++ b/xmcl-keystone-ui/locales/en.yaml
@@ -379,6 +379,11 @@ instance:
   name: Profile Name
   nameHint: The name of the modpack
   nameNoCyrillic: The name cannot contain Cyrillic characters
+  nameInvalidChars: 'The name cannot contain these characters: < > : " / \\ | ? *'
+  nameReservedName: This name is reserved by the system and cannot be used
+  namePathTraversal: The name cannot contain path traversal ("..")
+  nameWhitespaceOnly: The name cannot be only whitespace or dots
+  nameTrailingDotOrSpace: The name cannot end with a dot or space
   neverPlayed: Never Played
   openCrashReportFolder: Open Crash Report Folder
   openLogFolder: Open Log Folder

--- a/xmcl-keystone-ui/locales/zh-CN.yaml
+++ b/xmcl-keystone-ui/locales/zh-CN.yaml
@@ -347,6 +347,11 @@ instance:
   name: 名称
   nameHint: 名称便于以后识别
   nameNoCyrillic: 无西里尔字母名称
+  nameInvalidChars: '名称不能包含以下字符：< > : " / \\ | ? *'
+  nameReservedName: 此名称是系统保留名称，无法使用
+  namePathTraversal: 名称不能包含路径遍历符号（".."）
+  nameWhitespaceOnly: 名称不能仅由空格或点号组成
+  nameTrailingDotOrSpace: 名称不能以点号或空格结尾
   neverPlayed: 从未游玩
   openCrashReportFolder: 打开包含错误报告的文件夹
   openLogFolder: 打开日志文件夹

--- a/xmcl-keystone-ui/src/components/StepConfig.vue
+++ b/xmcl-keystone-ui/src/components/StepConfig.vue
@@ -76,6 +76,7 @@ import { basename } from '@/util/basename'
 import { injection } from '@/util/inject'
 import { required } from '@/util/props'
 import { kInstanceCreation } from '../composables/instanceCreation'
+import { validateInstanceName } from '@/util/instanceName'
 import ErrorView from './ErrorView.vue'
 import InstanceManifestFileTree from './InstanceManifestFileTree.vue'
 import StepperAdvanceContent from './StepperAdvanceContent.vue'
@@ -87,12 +88,24 @@ const emit = defineEmits(['update:valid'])
 const { t } = useI18n()
 const { data: content, files, loading, error, placeHolderName } = injection(kInstanceCreation)
 const { instances } = injection(kInstances)
+const nameValidationErrors: Record<string, string> = {
+  invalidChars: 'instance.nameInvalidChars',
+  reservedName: 'instance.nameReservedName',
+  pathTraversal: 'instance.namePathTraversal',
+  whitespaceOnly: 'instance.nameWhitespaceOnly',
+  trailingDotOrSpace: 'instance.nameTrailingDotOrSpace',
+}
 const nameRules = computed(() => [
-  // (v: any) => !!v || t('instance.requireName'),
   (v: any) => {
     const trimmed = v.trim()
     const effectiveName = trimmed || placeHolderName.value
     return !instances.value.some(i => i.name === effectiveName) || t('instance.duplicatedName')
+  },
+  (v: any) => {
+    if (!v) return true // empty is allowed, will use placeholder
+    const result = validateInstanceName(v)
+    if (result === true) return true
+    return t(nameValidationErrors[result] ?? 'instance.nameInvalidChars')
   },
   (v: any) => !/\p{Script=Cyrillic}/u.test(v) || t('instance.nameNoCyrillic'),
 ])

--- a/xmcl-keystone-ui/src/components/StepConfig.vue
+++ b/xmcl-keystone-ui/src/components/StepConfig.vue
@@ -89,7 +89,11 @@ const { data: content, files, loading, error, placeHolderName } = injection(kIns
 const { instances } = injection(kInstances)
 const nameRules = computed(() => [
   // (v: any) => !!v || t('instance.requireName'),
-  (v: any) => !instances.value.some(i => i.name === v.trim()) || t('instance.duplicatedName'),
+  (v: any) => {
+    const trimmed = v.trim()
+    const effectiveName = trimmed || placeHolderName.value
+    return !instances.value.some(i => i.name === effectiveName) || t('instance.duplicatedName')
+  },
   (v: any) => !/\p{Script=Cyrillic}/u.test(v) || t('instance.nameNoCyrillic'),
 ])
 

--- a/xmcl-keystone-ui/src/components/StepManualFTB.vue
+++ b/xmcl-keystone-ui/src/components/StepManualFTB.vue
@@ -51,6 +51,7 @@ import { kInstances } from '@/composables/instances'
 import { injection } from '@/util/inject'
 import { required } from '@/util/props'
 import { kInstanceCreation } from '../composables/instanceCreation'
+import { validateInstanceName } from '@/util/instanceName'
 import StepperAdvanceContent from './StepperAdvanceContent.vue'
 
 defineProps({
@@ -60,9 +61,22 @@ const emit = defineEmits(['update:valid'])
 const { t } = useI18n()
 const { data: content } = injection(kInstanceCreation)
 const { instances } = injection(kInstances)
+const nameValidationErrors: Record<string, string> = {
+  invalidChars: 'instance.nameInvalidChars',
+  reservedName: 'instance.nameReservedName',
+  pathTraversal: 'instance.namePathTraversal',
+  whitespaceOnly: 'instance.nameWhitespaceOnly',
+  trailingDotOrSpace: 'instance.nameTrailingDotOrSpace',
+}
 const nameRules = computed(() => [
   (v: any) => !!v || t('instance.requireName'),
   (v: any) => !instances.value.some(i => i.name === v) || t('instance.duplicatedName'),
+  (v: any) => {
+    if (!v) return true
+    const result = validateInstanceName(v)
+    if (result === true) return true
+    return t(nameValidationErrors[result] ?? 'instance.nameInvalidChars')
+  },
 ])
 
 const onUpdate = ($event: any) => {

--- a/xmcl-keystone-ui/src/util/instanceName.test.ts
+++ b/xmcl-keystone-ui/src/util/instanceName.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, test } from 'vitest'
+import { generateBaseName, generateDistinctName } from './instanceName'
+
+describe('generateBaseName', () => {
+  test('should return minecraft version as base name', () => {
+    expect(generateBaseName({ minecraft: '1.20.1' })).toBe('1.20.1')
+  })
+
+  test('should append forge version', () => {
+    expect(generateBaseName({ minecraft: '1.20.1', forge: '47.2.0' })).toBe('1.20.1-forge47.2.0')
+  })
+
+  test('should append fabric version', () => {
+    expect(generateBaseName({ minecraft: '1.20.1', fabricLoader: '0.14.21' })).toBe('1.20.1-fabric0.14.21')
+  })
+
+  test('should append quilt version', () => {
+    expect(generateBaseName({ minecraft: '1.20.1', quiltLoader: '0.19.0' })).toBe('1.20.1-quilt0.19.0')
+  })
+
+  test('should append neoforge version', () => {
+    expect(generateBaseName({ minecraft: '1.20.1', neoForged: '20.4.0' })).toBe('1.20.1-neoforge20.4.0')
+  })
+
+  test('should append labymod version', () => {
+    expect(generateBaseName({ minecraft: '1.20.1', labyMod: '4.0.0' })).toBe('1.20.1-labyMod4.0.0')
+  })
+
+  test('should append optifine alongside loader', () => {
+    expect(generateBaseName({ minecraft: '1.20.1', forge: '47.2.0', optifine: 'HD_U_I6' })).toBe('1.20.1-forge47.2.0-optifineHD_U_I6')
+  })
+
+  test('should only use first matching loader (forge > fabric > quilt > neoForged > labyMod)', () => {
+    expect(generateBaseName({ minecraft: '1.20.1', forge: '47.2.0', fabricLoader: '0.14.21' })).toBe('1.20.1-forge47.2.0')
+  })
+})
+
+describe('generateDistinctName', () => {
+  test('should return base name when no conflicts', () => {
+    expect(generateDistinctName('1.20.1', [])).toBe('1.20.1')
+    expect(generateDistinctName('1.20.1', ['1.19.4', '1.18.2'])).toBe('1.20.1')
+  })
+
+  test('should append -1 when name conflicts', () => {
+    expect(generateDistinctName('1.20.1', ['1.20.1'])).toBe('1.20.1-1')
+  })
+
+  test('should increment suffix until unique', () => {
+    // name accumulates: 1.20.1 -> 1.20.1-1 -> 1.20.1-1-2
+    expect(generateDistinctName('1.20.1', ['1.20.1', '1.20.1-1'])).toBe('1.20.1-1-2')
+    expect(generateDistinctName('1.20.1', ['1.20.1', '1.20.1-1', '1.20.1-1-2'])).toBe('1.20.1-1-2-3')
+  })
+
+  test('should handle empty base name', () => {
+    expect(generateDistinctName('', [''])).toBe('-1')
+  })
+})
+
+/**
+ * Test the name validation logic used in StepConfig.vue:
+ *   const effectiveName = trimmed || placeHolderName
+ *   return !instances.some(i => i.name === effectiveName)
+ *
+ * When the user leaves the name field empty, the effective name
+ * should be the placeholder (generated distinct name), NOT empty string.
+ */
+describe('instance name validation logic', () => {
+  /** Simulates the validation rule from StepConfig.vue */
+  function validateName(input: string, placeHolderName: string, instanceNames: string[]): boolean {
+    const trimmed = input.trim()
+    const effectiveName = trimmed || placeHolderName
+    return !instanceNames.some(name => name === effectiveName)
+  }
+
+  test('empty input with unique placeholder should be valid', () => {
+    // placeholder is "1.20.1" and no instance has that name
+    expect(validateName('', '1.20.1', ['my-server', 'test'])).toBe(true)
+  })
+
+  test('empty input with conflicting placeholder should be invalid', () => {
+    // placeholder is "1.20.1" but an instance already has that name
+    expect(validateName('', '1.20.1', ['1.20.1', 'other'])).toBe(false)
+  })
+
+  test('whitespace-only input should use placeholder', () => {
+    expect(validateName('   ', '1.20.1', ['1.20.1'])).toBe(false)
+    expect(validateName('   ', '1.20.1-1', ['1.20.1'])).toBe(true)
+  })
+
+  test('non-empty input should validate against actual input, not placeholder', () => {
+    expect(validateName('my-instance', '1.20.1', ['1.20.1'])).toBe(true)
+    expect(validateName('my-instance', '1.20.1', ['my-instance'])).toBe(false)
+  })
+
+  test('input matching placeholder but no conflict should be valid', () => {
+    expect(validateName('1.20.1', '1.20.1', [])).toBe(true)
+  })
+
+  test('original bug: empty input should NOT conflict with empty-name instances', () => {
+    // With the old logic: v.trim() === "" matches instance with name ""  -> false positive!
+    // With the fix: effectiveName = placeHolderName = "1.20.1", no conflict -> valid
+    expect(validateName('', '1.20.1', [''])).toBe(true)
+  })
+})

--- a/xmcl-keystone-ui/src/util/instanceName.test.ts
+++ b/xmcl-keystone-ui/src/util/instanceName.test.ts
@@ -1,37 +1,49 @@
 import { describe, expect, test } from 'vitest'
 import { generateBaseName, generateDistinctName } from './instanceName'
+import type { RuntimeVersions } from '@xmcl/instance'
+
+const rt = (overrides: Partial<RuntimeVersions>): RuntimeVersions => ({
+  minecraft: '',
+  forge: '',
+  neoForged: '',
+  fabricLoader: '',
+  quiltLoader: '',
+  optifine: '',
+  labyMod: '',
+  ...overrides,
+})
 
 describe('generateBaseName', () => {
   test('should return minecraft version as base name', () => {
-    expect(generateBaseName({ minecraft: '1.20.1' })).toBe('1.20.1')
+    expect(generateBaseName(rt({ minecraft: '1.20.1' }))).toBe('1.20.1')
   })
 
   test('should append forge version', () => {
-    expect(generateBaseName({ minecraft: '1.20.1', forge: '47.2.0' })).toBe('1.20.1-forge47.2.0')
+    expect(generateBaseName(rt({ minecraft: '1.20.1', forge: '47.2.0' }))).toBe('1.20.1-forge47.2.0')
   })
 
   test('should append fabric version', () => {
-    expect(generateBaseName({ minecraft: '1.20.1', fabricLoader: '0.14.21' })).toBe('1.20.1-fabric0.14.21')
+    expect(generateBaseName(rt({ minecraft: '1.20.1', fabricLoader: '0.14.21' }))).toBe('1.20.1-fabric0.14.21')
   })
 
   test('should append quilt version', () => {
-    expect(generateBaseName({ minecraft: '1.20.1', quiltLoader: '0.19.0' })).toBe('1.20.1-quilt0.19.0')
+    expect(generateBaseName(rt({ minecraft: '1.20.1', quiltLoader: '0.19.0' }))).toBe('1.20.1-quilt0.19.0')
   })
 
   test('should append neoforge version', () => {
-    expect(generateBaseName({ minecraft: '1.20.1', neoForged: '20.4.0' })).toBe('1.20.1-neoforge20.4.0')
+    expect(generateBaseName(rt({ minecraft: '1.20.1', neoForged: '20.4.0' }))).toBe('1.20.1-neoforge20.4.0')
   })
 
   test('should append labymod version', () => {
-    expect(generateBaseName({ minecraft: '1.20.1', labyMod: '4.0.0' })).toBe('1.20.1-labyMod4.0.0')
+    expect(generateBaseName(rt({ minecraft: '1.20.1', labyMod: '4.0.0' }))).toBe('1.20.1-labyMod4.0.0')
   })
 
   test('should append optifine alongside loader', () => {
-    expect(generateBaseName({ minecraft: '1.20.1', forge: '47.2.0', optifine: 'HD_U_I6' })).toBe('1.20.1-forge47.2.0-optifineHD_U_I6')
+    expect(generateBaseName(rt({ minecraft: '1.20.1', forge: '47.2.0', optifine: 'HD_U_I6' }))).toBe('1.20.1-forge47.2.0-optifineHD_U_I6')
   })
 
   test('should only use first matching loader (forge > fabric > quilt > neoForged > labyMod)', () => {
-    expect(generateBaseName({ minecraft: '1.20.1', forge: '47.2.0', fabricLoader: '0.14.21' })).toBe('1.20.1-forge47.2.0')
+    expect(generateBaseName(rt({ minecraft: '1.20.1', forge: '47.2.0', fabricLoader: '0.14.21' }))).toBe('1.20.1-forge47.2.0')
   })
 })
 

--- a/xmcl-keystone-ui/src/util/instanceName.test.ts
+++ b/xmcl-keystone-ui/src/util/instanceName.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { generateBaseName, generateDistinctName } from './instanceName'
+import { generateBaseName, generateDistinctName, validateInstanceName } from './instanceName'
 import type { RuntimeVersions } from '@xmcl/instance'
 
 const rt = (overrides: Partial<RuntimeVersions>): RuntimeVersions => ({
@@ -112,5 +112,68 @@ describe('instance name validation logic', () => {
     // With the old logic: v.trim() === "" matches instance with name ""  -> false positive!
     // With the fix: effectiveName = placeHolderName = "1.20.1", no conflict -> valid
     expect(validateName('', '1.20.1', [''])).toBe(true)
+  })
+})
+
+describe('validateInstanceName', () => {
+  test('should accept valid names', () => {
+    expect(validateInstanceName('my-instance')).toBe(true)
+    expect(validateInstanceName('1.20.1-forge47.2.0')).toBe(true)
+    expect(validateInstanceName('My Server 2')).toBe(true)
+    expect(validateInstanceName('测试实例')).toBe(true)
+    expect(validateInstanceName('instance_v2')).toBe(true)
+  })
+
+  test('should reject names with invalid characters', () => {
+    expect(validateInstanceName('my<instance')).toBe('invalidChars')
+    expect(validateInstanceName('my>instance')).toBe('invalidChars')
+    expect(validateInstanceName('my:instance')).toBe('invalidChars')
+    expect(validateInstanceName('my"instance')).toBe('invalidChars')
+    expect(validateInstanceName('my/instance')).toBe('invalidChars')
+    expect(validateInstanceName('my\\instance')).toBe('invalidChars')
+    expect(validateInstanceName('my|instance')).toBe('invalidChars')
+    expect(validateInstanceName('my?instance')).toBe('invalidChars')
+    expect(validateInstanceName('my*instance')).toBe('invalidChars')
+  })
+
+  test('should reject Windows reserved device names', () => {
+    expect(validateInstanceName('CON')).toBe('reservedName')
+    expect(validateInstanceName('PRN')).toBe('reservedName')
+    expect(validateInstanceName('AUX')).toBe('reservedName')
+    expect(validateInstanceName('NUL')).toBe('reservedName')
+    expect(validateInstanceName('COM1')).toBe('reservedName')
+    expect(validateInstanceName('COM9')).toBe('reservedName')
+    expect(validateInstanceName('LPT1')).toBe('reservedName')
+    expect(validateInstanceName('con')).toBe('reservedName')
+    expect(validateInstanceName('CON.txt')).toBe('reservedName')
+  })
+
+  test('should allow names that contain but are not reserved names', () => {
+    expect(validateInstanceName('CONTROLLER')).toBe(true)
+    expect(validateInstanceName('my-con')).toBe(true)
+    expect(validateInstanceName('AUXILIARY')).toBe(true)
+  })
+
+  test('should reject path traversal patterns', () => {
+    expect(validateInstanceName('..')).toBe('pathTraversal')
+    expect(validateInstanceName('../etc')).toBe('pathTraversal')
+    expect(validateInstanceName('foo/../bar')).toBe('pathTraversal')
+    expect(validateInstanceName('foo\\..\\bar')).toBe('pathTraversal')
+  })
+
+  test('should reject whitespace-only or dots-only names', () => {
+    expect(validateInstanceName('')).toBe('whitespaceOnly')
+    expect(validateInstanceName('   ')).toBe('whitespaceOnly')
+    expect(validateInstanceName('...')).toBe('whitespaceOnly')
+    expect(validateInstanceName('. .')).toBe('whitespaceOnly')
+  })
+
+  test('should reject names ending with dot or space', () => {
+    expect(validateInstanceName('instance.')).toBe('trailingDotOrSpace')
+    expect(validateInstanceName('instance ')).toBe('trailingDotOrSpace')
+  })
+
+  test('should accept names starting with dot (hidden dirs are ok)', () => {
+    expect(validateInstanceName('.minecraft')).toBe(true)
   })
 })

--- a/xmcl-keystone-ui/src/util/instanceName.ts
+++ b/xmcl-keystone-ui/src/util/instanceName.ts
@@ -27,3 +27,50 @@ export function generateDistinctName(baseName: string, names: string[]) {
   }
   return name
 }
+
+/**
+ * Characters that are invalid in Windows file/directory names.
+ * Also includes path separators which are dangerous on all platforms.
+ */
+const INVALID_CHARS_PATTERN = /[<>:"/\\|?*]/
+
+/**
+ * Windows reserved device names that cannot be used as directory names.
+ */
+const WINDOWS_RESERVED_NAMES = /^(CON|PRN|AUX|NUL|COM[0-9]|LPT[0-9])(\.|$)/i
+
+/**
+ * Path traversal patterns: ".." as a standalone segment
+ */
+const PATH_TRAVERSAL_PATTERN = /(^|[\\/])\.\.($|[\\/])/
+
+/**
+ * Names that consist of only whitespace or dots are invalid on Windows.
+ */
+const WHITESPACE_OR_DOTS_ONLY = /^[\s.]+$/
+
+/**
+ * Validate an instance name for filesystem safety.
+ * Returns `true` if the name is valid, or a string error key if invalid.
+ */
+export function validateInstanceName(name: string): true | 'empty' | 'invalidChars' | 'reservedName' | 'pathTraversal' | 'whitespaceOnly' | 'trailingDotOrSpace' {
+  if (!name) {
+    return 'whitespaceOnly'
+  }
+  if (PATH_TRAVERSAL_PATTERN.test(name)) {
+    return 'pathTraversal'
+  }
+  if (WHITESPACE_OR_DOTS_ONLY.test(name)) {
+    return 'whitespaceOnly'
+  }
+  if (INVALID_CHARS_PATTERN.test(name)) {
+    return 'invalidChars'
+  }
+  if (WINDOWS_RESERVED_NAMES.test(name)) {
+    return 'reservedName'
+  }
+  if (/[. ]$/.test(name)) {
+    return 'trailingDotOrSpace'
+  }
+  return true
+}


### PR DESCRIPTION
When the name field is empty, validate against the generated placeholder name instead of empty string. This prevents false 'duplicated name' errors when existing instances happen to have empty names.