### PR TITLE
feat(ui): hide skin-edit controls for Yggdrasil accounts

### DIFF
--- a/xmcl-keystone-ui/src/components/UserCardYggdrasil.vue
+++ b/xmcl-keystone-ui/src/components/UserCardYggdrasil.vue
@@ -13,6 +13,7 @@
         :user="user"
         :profile="profile"
         :inspect="false"
+        :editable="false"
         @wheel.prevent.stop.native
       />
       <div class="my-2 flex items-center justify-center">

--- a/xmcl-keystone-ui/src/components/UserSkin.vue
+++ b/xmcl-keystone-ui/src/components/UserSkin.vue
@@ -31,7 +31,7 @@
     <div class="absolute bottom-4 flex flex-none flex-shrink gap-4">
       <v-fab-transition>
         <v-btn
-          v-show="!inspect && modified"
+          v-show="!inspect && modified && editable"
           v-shared-tooltip="() => t('userSkin.reset')"
           icon="clear"
           color="secondary"
@@ -42,6 +42,7 @@
         />
       </v-fab-transition>
       <SpeedDial
+        v-if="editable"
         :value="hover || modified"
         :has-skin="canUploadSkin"
         :has-cape="canUploadCape"
@@ -52,7 +53,7 @@
       />
       <v-fab-transition>
         <v-btn
-          v-show="!inspect && modified"
+          v-show="!inspect && modified && editable"
           icon="check"
           color="secondary"
           size="small"
@@ -88,8 +89,17 @@ const props = withDefaults(
     user: UserProfile
     profile: GameProfileAndTexture
     inspect: boolean
+    /**
+     * When false, hide all skin-modification controls (reset, save,
+     * upload SpeedDial). The 3D viewer remains interactive.
+     *
+     * Use this for accounts where uploading a skin would not actually
+     * propagate to the auth provider (e.g. offline or some Yggdrasil
+     * services).
+     */
+    editable?: boolean
   }>(),
-  { inspect: false },
+  { inspect: false, editable: true },
 )
 const { t } = useI18n()
 const hover = ref(false)


### PR DESCRIPTION
## Overview

Adds an opt-out `editable` prop to `UserSkin` and uses it from `UserCardYggdrasil` so skin-modification controls are hidden for accounts where uploading a skin doesn't actually propagate to the auth provider.

This is the last of several feature branches split out from #1374, rebased onto current master.

## Changes

- `xmcl-keystone-ui/src/components/UserSkin.vue` — new `editable?: boolean` prop (default `true`). When `false`, the reset, save, and upload `SpeedDial` controls are hidden; the 3D viewer / inspector remains interactive.
- `xmcl-keystone-ui/src/components/UserCardYggdrasil.vue` — passes `:editable="false"` to `UserSkin`. Microsoft accounts (`UserCardMicrosoft`) keep skin editing enabled.

## Why

Offline accounts cannot persist skin uploads anywhere meaningful, and many Yggdrasil/authlib-injector services either reject uploads or only accept them through their own web portal — exposing the upload buttons leads to confusing silent failures.

## Out of scope (intentionally not included)

The original PR #1374 also restricted *all* third-party auth services to developer mode (a one-line change to `useAllowThirdparty` in `composables/login.ts`). That change is policy-sensitive — it would lock out users in non-strict locales who currently rely on third-party auth as their primary login — so it is left for the maintainer to opt in to in a separate PR if desired.

Originally authored by @v1mkss / @BANSAFAn in #1374.