### PR TITLE
chore(ci): retire azure release mirror

### DIFF
--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -4,50 +4,39 @@ on:
     types: [published]
 
 jobs:
-  publish:
+  refresh-appinstaller-mirror:
+    # Keep the legacy xmcl.appinstaller blob fresh so older clients that
+    # baked in https://xmcl.blob.core.windows.net/releases/xmcl.appinstaller
+    # before the api.xmcl.app/appinstaller switch keep auto-updating.
+    # Newly-built clients no longer poll the blob.
     runs-on: ubuntu-latest
     steps:
-    - name: Download Releases
-      uses: robinraju/release-downloader@v1.7
-      with:
-        repository: "voxelum/x-minecraft-launcher"
-        tag: ${{ github.event.release.tag_name }}
-        fileName: "*"
-        out-file-path: build
-    - name: Upload to Azure
-      uses: ci010/upload-blob-to-azure@master
-      env:
-        AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
-      with:
-        account: xmcl
-        container: releases
-        directory: ./build
-    - name: Update Web Page
-      uses: benc-uk/workflow-dispatch@v1
-      with:
-        workflow: Deploy
-        token: ${{ secrets.PAT_GITHUB_TOKEN }}
-        ref: 'master'
-        repo: 'voxelum/xmcl-page'
-    - name: Create release version file
-      run: |
-        mkdir releases
-        echo ${{ github.event.release.tag_name }} > ./releases/VERSION
-        cat << EOF > ./releases/latest_version.json
-        ${{ toJSON(github.event.release) }}
-        EOF
-    - name: Upload release version file to Azure
-      uses: ci010/upload-blob-to-azure@master
-      env:
-        AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
-      with:
-        account: xmcl
-        container: releases
-        directory: ./releases
+      - name: Fetch latest manifest from api.xmcl.app
+        run: |
+          mkdir releases
+          curl -fsSL https://api.xmcl.app/appinstaller -o ./releases/xmcl.appinstaller
+      - name: Upload to Azure
+        uses: ci010/upload-blob-to-azure@master
+        env:
+          AZURE_ACCOUNT_KEY: ${{ secrets.AZURE_ACCOUNT_KEY }}
+        with:
+          account: xmcl
+          container: releases
+          directory: ./releases
+
+  update-page:
+    name: Trigger xmcl-page rebuild
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Web Page
+        uses: benc-uk/workflow-dispatch@v1
+        with:
+          workflow: Deploy
+          token: ${{ secrets.PAT_GITHUB_TOKEN }}
+          ref: 'master'
+          repo: 'voxelum/xmcl-page'
 
   notify:
-    needs:
-      - publish
     name: Notify Kook and discord
     runs-on: ubuntu-latest
     steps:
@@ -59,8 +48,6 @@ jobs:
         discord: ${{ secrets.DISCORD_WEBHOOK }}
 
   update-brew:
-    needs: 
-      - publish
     name: Update Brew
     runs-on: ubuntu-latest
     steps:
@@ -122,8 +109,6 @@ jobs:
         branch: ${{ github.event.release.tag_name }}
 
   update-winget:
-    needs: 
-      - publish
     name: Upload To winget
     runs-on: windows-2019
     defaults:

--- a/xmcl-electron-app/build/appinstaller-builder.ts
+++ b/xmcl-electron-app/build/appinstaller-builder.ts
@@ -5,13 +5,13 @@ function getAppInstallerContent(version: string, publisher: string) {
   <AppInstaller
       xmlns="http://schemas.microsoft.com/appx/appinstaller/2018"
       Version="${version}.0"
-      Uri="https://xmcl.blob.core.windows.net/releases/xmcl.appinstaller" >
+      Uri="https://api.xmcl.app/appinstaller" >
       <MainPackage
           Name="XMCL"
           Publisher="${publisher}"
           Version="${version}.${process.env.BUILD_NUMBER || '0'}"
           ProcessorArchitecture="x64"
-          Uri="https://xmcl-core-api.azurewebsites.net/api/appx?version=${version}" />
+          Uri="https://cdn.xmcl.app/v${version}/xmcl-${version}-win32-x64.appx" />
       <UpdateSettings>
       </UpdateSettings>
   </AppInstaller>`

--- a/xmcl-electron-app/build/appinstaller-builder.ts
+++ b/xmcl-electron-app/build/appinstaller-builder.ts
@@ -11,7 +11,7 @@ function getAppInstallerContent(version: string, publisher: string) {
           Publisher="${publisher}"
           Version="${version}.${process.env.BUILD_NUMBER || '0'}"
           ProcessorArchitecture="x64"
-          Uri="https://cdn.xmcl.app/v${version}/xmcl-${version}-win32-x64.appx" />
+          Uri="https://api.xmcl.app/appx?version=${version}" />
       <UpdateSettings>
       </UpdateSettings>
   </AppInstaller>`

--- a/xmcl-electron-app/main/utils/updater.ts
+++ b/xmcl-electron-app/main/utils/updater.ts
@@ -131,7 +131,7 @@ async function downloadAppInstaller(
   } & DownloadBaseOptions,
 ): Promise<void> {
   const destination = join(app.getPath('downloads'), 'X Minecraft Launcher.appinstaller')
-  const url = 'https://xmcl.blob.core.windows.net/releases/xmcl.appinstaller'
+  const url = 'https://api.xmcl.app/appinstaller'
 
   await download({
     url,


### PR DESCRIPTION
Retires the per-release mirror that copies every GitHub Release asset into `xmcl.blob.core.windows.net/releases/`. EdgeOne (`cdn.xmcl.app`) already CDN-fronts GitHub Releases, so the mirror is dead weight.

> **Merge order matters:** depends on voxelum/xmcl-web-api#5. Land that one and let it deploy on Deno Deploy first, otherwise the new `refresh-appinstaller-mirror` job's curl will 404.

## Audit — what actually reads the mirror today?

| Caller | URL | Verdict |
| --- | --- | --- |
| `xmcl-web-api/api/releases.ts` (`/releases/:filename`) | redirects straight to `github.com/.../releases/download/v<v>/<file>` | already GH-direct, untouched |
| `xmcl-page/.vitepress/.../useDownloads.ts` | uses `result.browser_download_url` from the GH API (only `*.appinstaller` is special) | unchanged |
| Launcher `updater.ts#downloadAsarUpdate` | downloads `app-<v>-<platform>.asar(.gz)(.sha256)` from `github.com/.../releases/download/v<v>/...` | already GH-direct, untouched |
| Launcher `updater.ts#downloadAppInstaller` | hard-coded `xmcl.blob.core.windows.net/releases/xmcl.appinstaller` | **switched to `api.xmcl.app/appinstaller` here** |
| `appinstaller-builder.ts` (manifest baked into the build) | outer `Uri` was the blob, MainPackage `Uri` was Azure Functions | **switched to `api.xmcl.app/appinstaller` + `cdn.xmcl.app/v<v>/...` here** |

So no current launcher code reads the per-version `xmcl-<v>-*` blobs — they have been redundant since the redirect/CDN layer landed. The only piece that needed re-pointing is the AppInstaller manifest.

## Backward compat for old AppInstaller-installed clients

Old Windows installs have `xmcl.blob.core.windows.net/releases/xmcl.appinstaller` baked into their AppInstaller manifest and will poll that URL forever. To keep them updating, the new `refresh-appinstaller-mirror` job in `deploy-release.yml` simply `curl`s the dynamic manifest from `api.xmcl.app/appinstaller` after each release and writes the result back to that single blob. One tiny file (1 KB) per release, instead of ~17 files × N MB.

## Diff summary

- `.github/workflows/deploy-release.yml` (-61 / +28)
  - Drop the `publish` job: removes `robinraju/release-downloader@v1.7` plus two `upload-blob-to-azure` calls plus the inline `VERSION` / `latest_version.json` writer.
  - Add `refresh-appinstaller-mirror` job: 1× curl + 1× upload of `xmcl.appinstaller` only.
  - Hoist the `xmcl-page` workflow_dispatch into its own `update-page` job.
  - Drop `needs: [publish]` from `notify` and `update-brew` (the dependency is gone).
- `xmcl-electron-app/build/appinstaller-builder.ts`: outer `Uri` → `api.xmcl.app`, MainPackage `Uri` → `cdn.xmcl.app` direct.
- `xmcl-electron-app/main/utils/updater.ts`: `downloadAppInstaller` URL → `api.xmcl.app/appinstaller`.

## Compat note

`AZURE_ACCOUNT_KEY` is still required by this workflow (for the legacy-mirror refresh) and by `build.yml#upload-sourcemap`. Don't remove it.

## Follow-ups

- After ~a few weeks of telemetry showing zero traffic on the legacy `xmcl-<v>-*` blobs (we can enable Storage diagnostic logging into `xmcl-client-log` to confirm), prune them from the `releases` container. Keep `xmcl.appinstaller`, `db.sqlite`, `db.sqlite.sha1`.