### PR TITLE
feat(runtime): route GFW-inside requests to azure backup

### DIFF
--- a/xmcl-runtime/app/pluginApiFallback.ts
+++ b/xmcl-runtime/app/pluginApiFallback.ts
@@ -1,15 +1,38 @@
+import { kGFW } from '~/infra'
 import { UserService } from '~/user'
 import type { LauncherAppPlugin } from './LauncherAppPlugin'
 import type { Handler } from './LauncherProtocolHandler'
+
+// Routes that the Azure Functions backup (xmcl-core-api, EastAsia) serves
+// at parity with the Deno Deploy primary. Used to geo-route inside-GFW
+// users to the closer-and-more-reachable Azure edge for these endpoints,
+// while keeping WebSocket / RTC / translation / news on Deno where they
+// either don't exist on Azure yet or wouldn't fit the Y1 Consumption
+// pricing (long-lived connections).
+const AZURE_BACKUP_HOST = 'xmcl-core-api.azurewebsites.net'
+const AZURE_BACKUP_ROUTES = new Set([
+  '/latest',
+  '/flights',
+  '/notifications',
+  '/appx',
+  '/appinstaller',
+])
 
 export const pluginApiFallback: LauncherAppPlugin = (app) => {
   const handler: Handler = async ({ request, response }) => {
     if (request.url.host === 'api.xmcl.app') {
       const shouldDecorateHeaders = request.url.pathname === '/translation' || request.url.pathname === '/rtc/official'
-      // const gfw = await app.registry.get(kGFW)
-      // if (gfw.inside && shouldDecorateHeaders) {
-      //   request.url.host = 'api-xmcl.0xc.cn'
-      // }
+
+      // Inside GFW, swap the closest reachable host for the routes the
+      // Azure backup serves. Azure Functions are at /api/<name> by
+      // convention, so prepend /api to the pathname.
+      if (AZURE_BACKUP_ROUTES.has(request.url.pathname)) {
+        const gfw = await app.registry.get(kGFW)
+        if (gfw.inside) {
+          request.url.host = AZURE_BACKUP_HOST
+          request.url.pathname = '/api' + request.url.pathname
+        }
+      }
 
       if (shouldDecorateHeaders) {
         const accessToken = await app.registry.get(UserService)


### PR DESCRIPTION
For mainland-CN users, swap the request `host` on the `api.xmcl.app` routes that the Azure Functions backup (`xmcl-core-api`, EastAsia) serves at parity with the Deno Deploy primary. Same response shape, but lower latency + more reliable connectivity from inside the GFW.

## Mechanism

Activates the previously-commented `kGFW` branch in `xmcl-runtime/app/pluginApiFallback.ts`. The plugin already intercepts every main-process `app.fetch()` call to `api.xmcl.app`. We add a small allowlist of paths the Azure backup actually serves and, for `kGFW.inside === true`, rewrite the URL:

```diff
   if (request.url.host === 'api.xmcl.app') {
     const shouldDecorateHeaders = request.url.pathname === '/translation' || request.url.pathname === '/rtc/official'
-    // const gfw = await app.registry.get(kGFW)
-    // if (gfw.inside && shouldDecorateHeaders) {
-    //   request.url.host = 'api-xmcl.0xc.cn'
-    // }
+
+    if (AZURE_BACKUP_ROUTES.has(request.url.pathname)) {
+      const gfw = await app.registry.get(kGFW)
+      if (gfw.inside) {
+        request.url.host = 'xmcl-core-api.azurewebsites.net'
+        request.url.pathname = '/api' + request.url.pathname
+      }
+    }
```

## What's routed and what's not

| Route | After this PR | Reason |
| --- | --- | --- |
| `/latest`, `/flights`, `/notifications`, `/appx`, `/appinstaller` | CN → Azure, ROW → Deno | parity verified end-to-end on `xmcl-core-api` today |
| `/translation` | stays on Deno | uses DeepSeek + MongoDB; Azure variant doesn't expose it |
| `/group/:id`, `/rtc/official` | stays on Deno | WebSocket — Y1 Consumption bills the connection lifetime, would dominate cost |
| `/news` | stays on Deno | not on Azure backup |
| `/zulu`, `/elyby/authlib`, `/modrinth/auth`, `/kook-badge`, `/releases/:filename` | stays on Deno | not on Azure backup yet — small follow-up if we want them too |

## Scope of the interception

`pluginApiFallback` only fires on **main-process** `app.fetch()` calls. The renderer-side direct `fetch()` calls in `xmcl-keystone-ui/src/composables/{i18n.ts, launcherNews.ts}` bypass the interceptor entirely. They hit `/translation` and `/news` (both Deno-only routes anyway), so this PR doesn't change anything for them. Migrating those to use the main-process protocol hook would be a separate change.

## Verification

- `pnpm --prefix=xmcl-runtime check` passes.
- `xmcl-core-api` is currently live with all 5 listed routes (verified earlier today via `az functionapp function list` + HTTP probes returning 200/302).
- Smoke test plan once merged: build the launcher with `kGFW.inside` forced true (e.g. mock the registry in a scratch spec) and assert `app.fetch('https://api.xmcl.app/latest')` resolves to `xmcl-core-api.azurewebsites.net/api/latest`.