### PR TITLE
fix(sqlite): stop `Database already closed` error storm (#1429)

### DIFF
--- a/packages/sqlite/SqliteWASMDriver.ts
+++ b/packages/sqlite/SqliteWASMDriver.ts
@@ -95,10 +95,21 @@ export class SqliteWASMDriver extends AbstractSqliteDriver {
             e.message === 'Database already closed' ||
             e.message === 'unable to open database file'
           ) {
-            // reopen the database
-            this.#db?.close()
+            // The underlying handle is gone. Open a fresh one and swap it in
+            // place — the existing SqliteConnection picks up the new handle
+            // through its getter so callers that already acquired the
+            // connection don't keep hitting the closed db in a tight loop
+            // (root cause of issue #1429).
+            try {
+              this.#db?.close()
+            } catch {}
             this.#db = this.#config.database()
-            this.#connection = new SqliteConnection(this.#db, onError)
+            // Mark the original error as already-handled so the telemetry
+            // sink in xmcl-runtime can skip it instead of re-reporting it
+            // for every subsequent query.
+            if (e instanceof SQLite3Error) {
+              e.isDisposed = true
+            }
           } else {
             this.#config.onError?.(e)
           }
@@ -111,7 +122,7 @@ export class SqliteWASMDriver extends AbstractSqliteDriver {
         }
       }
     }
-    this.#connection = new SqliteConnection(this.#db, onError)
+    this.#connection = new SqliteConnection(() => this.#db!, onError)
   }
 
   async acquireConnection(): Promise<DatabaseConnection> {
@@ -131,18 +142,18 @@ export class SqliteWASMDriver extends AbstractSqliteDriver {
 }
 
 class SqliteConnection implements DatabaseConnection {
-  readonly #db: Database
+  readonly #getDb: () => Database
 
   constructor(
-    db: Database,
+    getDb: () => Database,
     private onError?: (error: unknown) => void,
   ) {
-    this.#db = db
+    this.#getDb = getDb
   }
 
   executeQuery<O>(compiledQuery: CompiledQuery): Promise<QueryResult<O>> {
     const { sql, parameters } = compiledQuery
-    const stmt = this.#db.prepare(sql)
+    const stmt = this.#getDb().prepare(sql)
 
     try {
       if (stmt.isReader()) {
@@ -176,7 +187,7 @@ class SqliteConnection implements DatabaseConnection {
     _chunkSize: number,
   ): AsyncIterableIterator<QueryResult<R>> {
     const { sql, parameters, query } = compiledQuery
-    const stmt = this.#db.prepare(sql)
+    const stmt = this.#getDb().prepare(sql)
     try {
       if (SelectQueryNode.is(query)) {
         const iter = stmt.iterate(parameters as any) as IterableIterator<R>

--- a/xmcl-runtime/infra/errors/ErrorDiagnose.ts
+++ b/xmcl-runtime/infra/errors/ErrorDiagnose.ts
@@ -24,6 +24,18 @@ export class ErrorDiagnose {
    */
   processError(e: Error): boolean {
     if (e.name === 'SQLite3Error') {
+      // The driver already auto-reopens the handle on these transient
+      // failures (see SqliteWASMDriver). Suppress them from telemetry so we
+      // don't get the per-user storm reported in issue #1429.
+      if ((e as any).isDisposed) {
+        return true
+      }
+      if (
+        e.message === 'Database already closed' ||
+        e.message === 'unable to open database file'
+      ) {
+        return true
+      }
       if (e.message.startsWith('disk I/O error')) {
         this.#sqlDiskIOError = true
       }


### PR DESCRIPTION
Fixes #1429 (P0).

## Problem

App Insights (`xmcl-client-insight`, 14d window) showed:

| problemId | events | users | events/user |
| --- | --- | --- | --- |
| `SQLite3Error at Database2._assertOpen` | 16 642 | 8 | ~2 080 |
| `SQLite3Error at Database2._handleError` | 2 424 | 13 | ~187 |
| `SQLite3Error at new Database` | 1 187 | 14 | ~85 |

~2k events per affected user for `_assertOpen` is the smoking gun: a single user session is stuck in a retry loop emitting the same exception over and over.

## Root cause

The driver already attempts to recover from `Database already closed`, `Database is locked` and `unable to open database file` by reopening the handle, but:

1. It threw away the existing `SqliteConnection` and built a brand new wrapper. Any caller still holding the old wrapper (every queued `acquireConnection` consumer) kept calling `prepare` on the closed `#db` reference, generating one `SQLite3Error` per query.
2. The original error was still rejected to the caller (`Promise.reject(e)` from `executeQuery`) without any "already-handled" marker, so the runtime `app.logEmitter('failure')` sink in `xmcl-runtime/infra/plugins/telemetry.ts` ran `trackException` for every single rejection.
3. `ErrorDiagnose.processError` only filtered SQLite errors on a `diskFull` flag, and only rate-limited `database is locked` — it had nothing for the dispose path.

## Fix

- `SqliteConnection` now resolves the underlying `Database` through a `getDb` getter, so the driver swaps the handle in place on reopen and the existing wrapper picks up the new one automatically.
- After reopen, mark the original `SQLite3Error` with `isDisposed = true` (the typing for this flag already exists in the module augmentation at the top of `SqliteWASMDriver.ts`).
- `ErrorDiagnose.processError` now suppresses telemetry for `SQLite3Error` with `isDisposed === true` and for the bare `Database already closed` / `unable to open database file` messages, matching what the driver has already recovered from.

## Out of scope (follow-ups)

- `no such table: resources` / `no such table: snapshots` (the `_handleError` family) is a missing-migration issue rather than a dispose-loop, and it needs a separate change (idempotent `CREATE TABLE IF NOT EXISTS` on open). Tracked as part of #1429 but intentionally left for a follow-up PR so this one stays focused on the storm.
- `SQLite3Error at new Database` (`Could not open the database`) is almost always OneDrive / AV / read-only path; the right fix is a one-time UI toast, not a code change in the driver.

## Verification (after next release)

```kusto
exceptions
| where application_Version startswith "0.57"
| where problemId in ("SQLite3Error at Database2._assertOpen",
                      "SQLite3Error at Database2._handleError",
                      "SQLite3Error at new Database")
| summarize cnt=count(), users=dcount(user_Id),
            per_user = count() * 1.0 / dcount(user_Id) by problemId
```

Expect `per_user` for `_assertOpen` to drop from ~2 080 to ~1 and `cnt` to drop sharply.

## Validation

- `pnpm --filter @xmcl/runtime check` — clean.
- `pnpm --filter @xmcl/runtime lint` — only pre-existing warnings, none from these files.
