### PR TITLE
fix(resource): route broken jars to ParseException + notify user (#1431)

### DIFF
--- a/packages/resource/ResourceContext.ts
+++ b/packages/resource/ResourceContext.ts
@@ -21,5 +21,5 @@ export interface ResourceContext {
 
   onError(e: Error): void
 
-  throwException(exception: { type: 'parseResourceException'; code: string }): never
+  throwException(exception: { type: 'parseResourceException'; code: string; path: string }): never
 }

--- a/packages/resource/ResourcesState.ts
+++ b/packages/resource/ResourcesState.ts
@@ -3,13 +3,33 @@ import { ResourceMetadata } from './ResourceMetadata'
 
 export type ResourceActionTuple = [Resource, 0] | [string, 1] | [UpdateResourcePayload[], 2]
 
+export type ResourceErrorActionTuple = [ResourceError, 0] | [string, 1]
+
+export interface ResourceError {
+  path: string
+  code: string
+}
+
 export interface ResourceState {
   /**
    * The mods under instance folder
    */
   files: Resource[]
 
+  /**
+   * Files in this directory that could not be parsed (broken/corrupted
+   * zips, permission errors, …). Surfaced so the UI can tell the user
+   * *which* file is broken instead of silently dropping it.
+   *
+   * Keyed by `path` — re-adding the same path replaces the entry, and a
+   * successful upsert of the same path (i.e. the user fixed it) clears
+   * it via a `Remove` action.
+   */
+  errors: ResourceError[]
+
   filesUpdates(ops: ResourceActionTuple[]): void
+
+  errorsUpdates(ops: ResourceErrorActionTuple[]): void
 }
 
 export /* @__PURE__ */ const enum ResourceAction {
@@ -25,6 +45,17 @@ export /* @__PURE__ */ const enum ResourceAction {
    * Update multiple resources metadata
    */
   BatchUpdate = 2,
+}
+
+export /* @__PURE__ */ const enum ResourceErrorAction {
+  /**
+   * Upsert a resource parse error
+   */
+  Upsert = 0,
+  /**
+   * Remove a resource parse error by path (the file is gone or now parses)
+   */
+  Remove = 1,
 }
 
 export type UpdateResourcePayload = {

--- a/packages/resource/core/getOrParseMetadata.ts
+++ b/packages/resource/core/getOrParseMetadata.ts
@@ -42,7 +42,7 @@ export async function getOrParseMetadata(
       err.name === 'FileNotFoundError' ||
       err.name === 'PermissionError'
     ) {
-      context.throwException({ type: 'parseResourceException', code: err.name })
+      context.throwException({ type: 'parseResourceException', code: err.name, path: file.path })
     }
     throw err
   }

--- a/packages/resource/core/watchResourcesDirectory.ts
+++ b/packages/resource/core/watchResourcesDirectory.ts
@@ -6,7 +6,7 @@ import { ResourceContext } from '../ResourceContext'
 import { ResourceDomain } from '../ResourceDomain'
 import { ResourceMetadata } from '../ResourceMetadata'
 import { ResourceWorkerQueuePayload } from '../ResourceWorkerQueuePayload'
-import { ResourceAction, ResourceActionTuple, UpdateResourcePayload } from '../ResourcesState'
+import { ResourceAction, ResourceActionTuple, ResourceErrorAction, ResourceErrorActionTuple, UpdateResourcePayload } from '../ResourcesState'
 import { ResourceSnapshotTable } from '../schema'
 import { generateResourceV3, pickMetadata } from './generateResource'
 import { getFile, getFiles } from './getFile'
@@ -273,6 +273,11 @@ export function watchResourcesDirectory({
     (all) => state.filesUpdates(all),
     500,
   )
+  const errorUpdate = new AggregateExecutor<ResourceErrorActionTuple, ResourceErrorActionTuple[]>(
+    (v) => v,
+    (all) => state.errorsUpdates(all),
+    500,
+  )
 
   const state = context.createResourceState()
 
@@ -286,6 +291,7 @@ export function watchResourcesDirectory({
       .catch((e) => {})
 
     update.push([file, ResourceAction.Remove])
+    errorUpdate.push([file, ResourceErrorAction.Remove])
   }
 
   const onResourceEmit: ResouceEmitFunc = (file, record, metadata) => {
@@ -294,6 +300,10 @@ export function watchResourcesDirectory({
       context.onError(new AnyError('ResourcePathError', 'Resource path is not available'))
       return
     }
+    // The file parsed successfully — clear any prior parse-error entry so
+    // the UI stops complaining about it (covers the "user replaced the
+    // broken jar with a working one" flow).
+    errorUpdate.push([resource.path, ResourceErrorAction.Remove])
     update.push([resource, ResourceAction.Upsert])
   }
 
@@ -355,6 +365,16 @@ export function watchResourcesDirectory({
     }
     if (!(e instanceof Error)) {
       e = Object.assign(new Error(), e)
+    }
+    // If the parse failed with a known broken-file signature (the
+    // upstream `getOrParseMetadata.handleParseError` routes those through
+    // `context.throwException` → `ParseException`), surface it on the
+    // state so the UI can toast the user the path of the offending file.
+    // Other errors (logic bugs, IO surprises) still go to `onError` for
+    // telemetry.
+    const ex = (e as any)?.exception
+    if (ex && ex.type === 'parseResourceException' && typeof ex.code === 'string') {
+      errorUpdate.push([{ path: filePath, code: ex.code }, ResourceErrorAction.Upsert])
     }
     context.onError(e)
   }

--- a/packages/resource/parsers/index.ts
+++ b/packages/resource/parsers/index.ts
@@ -88,6 +88,19 @@ export class ResourceParser {
       if (e.message.startsWith('compressed/uncompressed size mismatch for stored file')) {
         Object.assign(e, { name: 'CompressedUncompressedSizeMismatchError' })
       }
+      // Malformed EOCD record (truncated/corrupted zip — common for jars
+      // downloaded with a broken transfer). yauzl throws a plain Error
+      // without a discriminating name, so route by message and let the
+      // upstream `handleParseError` map it to `parseResourceException`
+      // (an `Exception`, which the telemetry sink skips). See #1431.
+      if (e.message.startsWith('invalid comment length')) {
+        Object.assign(e, { name: 'InvalidZipFileError' })
+        throw e
+      }
+      if (e.message === 'end of central directory record signature not found') {
+        Object.assign(e, { name: 'InvalidZipFileError' })
+        throw e
+      }
       if ('code' in e) {
         if (e.code === 'ENOENT') {
           Object.assign(e, { name: 'FileNotFoundError' })

--- a/xmcl-keystone-ui/locales/en.yaml
+++ b/xmcl-keystone-ui/locales/en.yaml
@@ -1030,6 +1030,11 @@ quiltVersion:
   empty: Quilt does not support Minecraft {version}
 reinstall:
   name: Reinstall {version}
+resourceError:
+  title: Cannot read {file}
+  body: >-
+    "{path}" could not be parsed ({code}). The file may be corrupted, locked, or
+    incomplete. Try re-downloading or removing it.
 resourcepack:
   compatible: Compatible format {format} with {version}
   defaultDescription: The default look and feel of Minecraft

--- a/xmcl-keystone-ui/locales/zh-CN.yaml
+++ b/xmcl-keystone-ui/locales/zh-CN.yaml
@@ -1031,6 +1031,11 @@ quiltVersion:
   empty: Minecraft {version} 不支持 Quilt
 reinstall:
   name: 重新安装 {version}
+resourceError:
+  title: 无法读取 {file}
+  body: >-
+    “{path}” 解析失败（{code}）。该文件可能已损坏、被占用或下载不完整。
+    请尝试重新下载或删除该文件。
 resourcepack:
   compatible: 当前格式({format}) 可用于当前版本 {version}
   defaultDescription: Minecraft 的默认材质

--- a/xmcl-keystone-ui/locales/zh-TW.yaml
+++ b/xmcl-keystone-ui/locales/zh-TW.yaml
@@ -1582,6 +1582,11 @@ migrateMinecraft:
   name: 遷移 Minecraft 檔案
 reinstall:
   name: 重新安裝 {version}
+resourceError:
+  title: 無法讀取 {file}
+  body: >-
+    「{path}」解析失敗（{code}）。該檔案可能已損毀、被佔用或下載不完整。
+    請嘗試重新下載或刪除該檔案。
 minecraftFriends:
   title: Minecraft 好友
   add: 新增好友

--- a/xmcl-keystone-ui/src/composables/instanceMods.ts
+++ b/xmcl-keystone-ui/src/composables/instanceMods.ts
@@ -7,6 +7,7 @@ import { InstanceModsServiceKey, JavaRecord, ResourceState, SharedState } from '
 import debounce from 'lodash.debounce'
 import { InjectionKey, Ref } from 'vue'
 import { useLocalStorageCache } from './cache'
+import { useResourceParseErrorNotifier } from './resourceParseError'
 import { useService } from './service'
 import { useState } from './syncableState'
 import { RuntimeVersions } from '@xmcl/instance'
@@ -62,6 +63,8 @@ export function useInstanceMods(instancePath: Ref<string>, instanceRuntime: Ref<
     mods.files = mods.files.map(m => markRaw(m))
     return mods as any
   }, ReactiveResourceState)
+
+  useResourceParseErrorNotifier(state)
 
   const modsRaw: Ref<ModFile[]> = shallowRef([])
   const mods = refThrottled(modsRaw, 500)

--- a/xmcl-keystone-ui/src/composables/instanceResourcePack.ts
+++ b/xmcl-keystone-ui/src/composables/instanceResourcePack.ts
@@ -9,6 +9,7 @@ import {
   packFormatVersionRange,
 } from "@xmcl/runtime-api";
 import { computed, InjectionKey, Ref } from "vue";
+import { useResourceParseErrorNotifier } from "./resourceParseError";
 import { useService } from "./service";
 import { useState } from "./syncableState";
 import { Resource } from "@xmcl/resource";
@@ -104,6 +105,8 @@ export function useInstanceResourcePacks(
     () => (path.value ? watch(path.value) : undefined),
     ReactiveResourceState
   );
+
+  useResourceParseErrorNotifier(state);
 
   const { t } = useI18n();
 

--- a/xmcl-keystone-ui/src/composables/instanceShaderPack.ts
+++ b/xmcl-keystone-ui/src/composables/instanceShaderPack.ts
@@ -6,6 +6,7 @@ import { GameOptionsState, InstanceOptionsServiceKey, InstanceShaderPacksService
 import debounce from 'lodash.debounce'
 import { InjectionKey, Ref } from 'vue'
 import { useRefreshable } from './refreshable'
+import { useResourceParseErrorNotifier } from './resourceParseError'
 import { useService } from './service'
 import { useState } from './syncableState'
 import { ReactiveResourceState } from '@/util/ReactiveResourceState'
@@ -26,6 +27,8 @@ export function useInstanceShaderPacks(instancePath: Ref<string>, runtime: Ref<R
   const { editOculusShaderOptions, getOculusShaderOptions, getIrisShaderOptions, editIrisShaderOptions, getShaderOptions, editShaderOptions } = useService(InstanceOptionsServiceKey)
 
   const { state, error, isValidating } = useState(() => instancePath.value ? watchShaderPacks(instancePath.value) : undefined, ReactiveResourceState)
+
+  useResourceParseErrorNotifier(state)
 
   const shaderPacks = computed(() => state.value?.files.map(f => ({
     path: f.path,

--- a/xmcl-keystone-ui/src/composables/resourceParseError.ts
+++ b/xmcl-keystone-ui/src/composables/resourceParseError.ts
@@ -1,0 +1,43 @@
+import { ResourceErrorAction, ResourceErrorActionTuple } from '@xmcl/resource'
+import { ResourceState, SharedState } from '@xmcl/runtime-api'
+import { Ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { basename } from '@/util/basename'
+import { useNotifier } from './notifier'
+
+/**
+ * Surface `ResourceState.errors` updates as user-facing toasts so the
+ * user can see exactly which file the resource subsystem could not
+ * parse (broken zip, permission denied, …).
+ *
+ * The upstream `watchResourcesDirectory` pushes one `Upsert` per failing
+ * file (via the `ParseException` → `errorsUpdates` channel) and one
+ * `Remove` once the file disappears or starts parsing again. We toast on
+ * `Upsert` only, with the basename in the title and the full path / code
+ * in the body — same shape as the other warning toasts in the app.
+ */
+export function useResourceParseErrorNotifier(state: Ref<SharedState<ResourceState> | undefined>) {
+  const { t } = useI18n()
+  const { notify } = useNotifier()
+
+  watch(state, (s, _, onCleanup) => {
+    if (!s) return
+    const handler = (ops: ResourceErrorActionTuple[]) => {
+      for (const [payload, action] of ops) {
+        if (action !== ResourceErrorAction.Upsert) continue
+        const err = payload as { path: string; code: string }
+        if (!err?.path) continue
+        notify({
+          level: 'warning',
+          icon: 'broken_image',
+          title: t('resourceError.title', { file: basename(err.path) }),
+          body: t('resourceError.body', { path: err.path, code: err.code }),
+        })
+      }
+    }
+    s.subscribe('errorsUpdates', handler)
+    onCleanup(() => {
+      s.unsubscribe('errorsUpdates', handler)
+    })
+  }, { immediate: true })
+}

--- a/xmcl-keystone-ui/src/util/ReactiveResourceState.ts
+++ b/xmcl-keystone-ui/src/util/ReactiveResourceState.ts
@@ -1,4 +1,4 @@
-import { ResourceAction, ResourceActionTuple, UpdateResourcePayload } from '@xmcl/resource'
+import { ResourceAction, ResourceActionTuple, ResourceError, ResourceErrorAction, ResourceErrorActionTuple, UpdateResourcePayload } from '@xmcl/resource'
 import { ResourceState, applyUpdateToResource } from '@xmcl/runtime-api'
 
 
@@ -27,5 +27,26 @@ export class ReactiveResourceState extends ResourceState {
       }
     }
     this['files'] = mods
+  }
+
+  override errorsUpdates(ops: ResourceErrorActionTuple[]) {
+    const errors = [...this.errors]
+    for (const [payload, action] of ops) {
+      if (action === ResourceErrorAction.Upsert) {
+        const err = payload as ResourceError
+        if (!err || !err.path) continue
+        const index = errors.findIndex(e => e.path === err.path)
+        if (index === -1) {
+          errors.push(markRaw(err))
+        } else {
+          errors[index] = markRaw(err)
+        }
+      } else {
+        const path = payload as string
+        const index = errors.findIndex(e => e.path === path)
+        if (index !== -1) errors.splice(index, 1)
+      }
+    }
+    this['errors'] = errors
   }
 }

--- a/xmcl-runtime-api/src/entities/resource.ts
+++ b/xmcl-runtime-api/src/entities/resource.ts
@@ -1,4 +1,4 @@
-import { ResourceAction, type Resource, type ResourceActionTuple, type UpdateResourcePayload } from '@xmcl/resource'
+import { ResourceAction, ResourceErrorAction, type Resource, type ResourceActionTuple, type ResourceError, type ResourceErrorActionTuple, type UpdateResourcePayload } from '@xmcl/resource'
 
 export function applyUpdateToResource(resource: Resource, update: UpdateResourcePayload) {
   resource.name = update.metadata?.name ?? resource.name
@@ -14,6 +14,15 @@ export class ResourceState {
    * The mods under instance folder
    */
   files = [] as Resource[]
+
+  /**
+   * Files in this directory that could not be parsed (broken zip,
+   * permission, …). See `ResourceState.errors` in
+   * `@xmcl/resource/ResourcesState.ts` for the contract — the runtime
+   * pushes a `ResourceError` per failing file, and the renderer surfaces
+   * them as a user-facing toast.
+   */
+  errors = [] as ResourceError[]
 
   filesUpdates(ops: ResourceActionTuple[]) {
     const files = [...this.files]
@@ -43,5 +52,26 @@ export class ResourceState {
       }
     }
     this.files = files
+  }
+
+  errorsUpdates(ops: ResourceErrorActionTuple[]) {
+    const errors = [...this.errors]
+    for (const [payload, action] of ops) {
+      if (action === ResourceErrorAction.Upsert) {
+        const err = payload as ResourceError
+        if (!err || !err.path) continue
+        const index = errors.findIndex(e => e.path === err.path)
+        if (index === -1) {
+          errors.push(err)
+        } else {
+          errors[index] = err
+        }
+      } else {
+        const path = payload as string
+        const index = errors.findIndex(e => e.path === path)
+        if (index !== -1) errors.splice(index, 1)
+      }
+    }
+    this.errors = errors
   }
 }

--- a/xmcl-runtime-api/src/services/InstanceResourcesService.ts
+++ b/xmcl-runtime-api/src/services/InstanceResourcesService.ts
@@ -1,4 +1,5 @@
 import type { ResourceState } from '@xmcl/resource'
+import { Exception, ExceptionBase } from '../entities/exception'
 import { InstallMarketOptionWithInstance } from '../entities/market'
 import { SharedState } from '../util/SharedState'
 
@@ -45,4 +46,26 @@ export interface InstanceResourcesService {
    */
   refreshMetadata(instancePath: string): Promise<void>
 }
+
+/**
+ * Raised when a resource file (mod/resourcepack/shaderpack/…) cannot be
+ * parsed by `@xmcl/resource`. Carries the on-disk `path` so the UI can
+ * tell the user *which* file is broken, and a `code` identifying the
+ * underlying parser failure (e.g. `InvalidZipFileError`,
+ * `MultiDiskZipFileError`, `PermissionError`).
+ *
+ * This is intentionally an `Exception` (not an `Error`) so the runtime
+ * telemetry sink skips it — see knowledge/runbooks/telemetry-triage.md
+ * for the `Exception` vs `Error` doctrine. A broken jar in the user's
+ * mods folder is environment state, not a launcher defect.
+ */
+export interface ParseResourceException extends ExceptionBase {
+  type: 'parseResourceException'
+  code: string
+  path: string
+}
+
+export type ParseExceptions = ParseResourceException
+
+export class ParseException extends Exception<ParseExceptions> { }
 

--- a/xmcl-runtime/resource/pluginResourceWorker.ts
+++ b/xmcl-runtime/resource/pluginResourceWorker.ts
@@ -9,6 +9,7 @@ import {
   Exception,
   InstanceServiceKey,
   InstanceState,
+  ParseException,
   ResourceState,
   SharedState,
 } from '@xmcl/runtime-api'
@@ -90,7 +91,6 @@ function loadDatabaseConfig(app: LauncherApp, flights: any) {
 
   return config
 }
-class ParseException extends Exception<{ type: 'parseResourceException'; code: string }> {}
 
 export const pluginResourceWorker: LauncherAppPlugin = async (app) => {
   const workerLogger = app.getLogger('ResourceWorker')
@@ -186,8 +186,8 @@ export const pluginResourceWorker: LauncherAppPlugin = async (app) => {
     onError: (e) => {
       logger.error(e)
     },
-    throwException: ({ type, code }) => {
-      throw new ParseException({ type, code })
+    throwException: ({ type, code, path }) => {
+      throw new ParseException({ type, code, path })
     },
     createResourceState: function (): ResourceState {
       return new ResourceState()


### PR DESCRIPTION
Fixes #1431 (P1).

## Problem

App Insights (`xmcl-client-insight`, 14d window) showed **9 026 events / 42 users** for `Error at <no_method>: invalid comment length. expected: <N>. found: <M>` in `resource.worker.worker.js`. The high events-per-user ratio (~215) is the corruption-storm signature.

Per the telemetry-triage runbook (`Exception` vs `Error` doctrine): a corrupted jar in the user's `mods/`/`resourcepacks/`/`shaderpacks/` folder is **environment state**, not a launcher defect. It must not reach App Insights `trackException` — and the user should see *which* file is broken so they can fix it.

## Fix (two commits)

### 1) `fix(resource): map "invalid comment length" to InvalidZipFileError` (`1854b9a9`)

`yauzl` throws a plain `Error` (no discriminating `name`) when the EOCD record's comment-length field is malformed, so `ResourceParser.parse`'s catch in `packages/resource/parsers/index.ts` didn't rewrite the `name`, and the upstream `getOrParseMetadata.handleParseError` allow-list (which matches by `name`) never routed it through `context.throwException`.

Mapping it to `InvalidZipFileError` makes the existing exception channel take over:

```
yauzl Error → name rewrite → handleParseError → context.throwException
→ ParseException (instanceof Exception) → telemetry sink skips it
```

### 2) `feat(resource): notify user when a file cannot be parsed` (`2b786e35`)

Suppression alone is silent to the user. This commit wires the friendly UI hint the runbook calls for:

- **`ParseException` carries the file `path`.** `ResourceContext.throwException` signature gains `path`; `getOrParseMetadata` passes `file.path`; the class moves out of `pluginResourceWorker.ts` into `xmcl-runtime-api/src/services/InstanceResourcesService.ts` so the renderer can `isException(ParseException, e)`.
- **`ResourceState` gets an `errors` channel.** New `errors: ResourceError[]` field + `errorsUpdates(ops)` mutation, defined in both `packages/resource/ResourcesState.ts` and `xmcl-runtime-api/src/entities/resource.ts`, with the reactive override in `xmcl-keystone-ui/src/util/ReactiveResourceState.ts`. `watchResourcesDirectory` pushes one `Upsert` per failing file (when the worker rejection carries the `parseResourceException` shape) and one `Remove` when the file is removed or starts parsing again — so the toast clears itself once the user fixes the jar.
- **Renderer toasts via the existing notifier.** New `useResourceParseErrorNotifier(state)` composable subscribes to `errorsUpdates` and pushes a `LocalNotification` (`level: warning`, `icon: broken_image`) with `basename` in the title and full path + parser code in the body. Called from `instanceMods.ts`, `instanceResourcePack.ts`, `instanceShaderPack.ts`. i18n strings added for `en`, `zh-CN`, `zh-TW`.

## Why not the original worker-wrapper / deny-list / annotations approach

Reviewed off-thread:
- Telemetry annotations (`resourcePath`, `parser`, `fileSize`) would have been shipping noise to the backend for what is a user-data problem.
- The deny-list was solving a derived problem (re-parse storm) that goes away on its own once the storm-emitter (the unsuppressed `trackException`) is gone.
- A bespoke `BadResourceException` would have duplicated the existing `ParseException` channel.

## Verification (after next release)

```kusto
exceptions
| where application_Version startswith "0.57"
| where outerMessage startswith "invalid comment length"
| summarize events=count(), users=dcount(user_Id)
```

Expect both `events` and `users` to drop to ~0. The condition isn't gone for the affected user — their jar is still broken — but it's no longer reported to telemetry (correct behaviour for environment state) and the user now sees a warning toast naming the file so they can replace it.

## Validation

- `pnpm --filter @xmcl/runtime check` — clean.
- `pnpm --filter @xmcl/keystone-ui check` — only the pre-existing `MarketTextFieldWithMenu.vue` master error remains; no new errors from these changes.
