### PR TITLE
fix(telemetry): land locale + route in customDimensions for i18n compile errors (#1427)

### DIFF
--- a/xmcl-keystone-ui/src/telemetry.ts
+++ b/xmcl-keystone-ui/src/telemetry.ts
@@ -12,7 +12,15 @@ const appInsights = new ApplicationInsights({
 })
 appInsights.loadAppInsights()
 
-// Add telemetry initializer to filter exceptions
+// Add telemetry initializer to filter exceptions and enrich the ones we
+// want to investigate with renderer-side context.
+//
+// See issue #1427: the previous version wrote `exception.locale = ...`
+// directly to `envelope.data`, but the App Insights JS SDK promotes
+// custom dimensions through `envelope.baseData.properties`, so the
+// locale never reached `customDimensions` and the App Insights query
+// `extend locale = tostring(customDimensions.locale)` came back empty
+// for all 8 869 matching events / 902 users in a 14d window.
 appInsights.addTelemetryInitializer((envelope) => {
   if (envelope.baseType === 'ExceptionData') {
     const exception = envelope.data
@@ -27,7 +35,21 @@ appInsights.addTelemetryInitializer((envelope) => {
         return false
       }
       if (exception.message.includes('SyntaxError: {"code":24}')) {
-        exception.locale = (i18n.global.locale as any).value
+        const baseData: any = envelope.baseData = envelope.baseData ?? {}
+        const properties = baseData.properties = baseData.properties ?? {}
+        try {
+          properties.locale = (i18n.global.locale as any).value
+        } catch {}
+        try {
+          // The renderer uses createWebHashHistory, so the active route
+          // lives in window.location.hash (e.g. "#/mod/foo"). Capturing
+          // it lets us narrow the broken translation key to a single
+          // screen in the next release.
+          properties.route = typeof window !== 'undefined' ? window.location.hash : ''
+        } catch {}
+        // Keep the legacy field for back-compat in case anything else
+        // reads it off `envelope.data`.
+        ;(exception as any).locale = properties.locale
       }
     }
   }


### PR DESCRIPTION
Addresses #1427 (P1, "needs more telemetry" classification).

## Problem

The renderer telemetry initializer in `xmcl-keystone-ui/src/telemetry.ts` already had a branch for the vue-i18n `SyntaxError: {"code":24}` (`UNTERMINATED_CLOSING_BRACE`) compile error that **168 distinct users** hit in a 14-day window. It tried to capture the active locale:

```ts
if (exception.message.includes('SyntaxError: {"code":24}')) {
  exception.locale = (i18n.global.locale as any).value
}
```

…but in `@microsoft/applicationinsights-web` the field that ends up in `customDimensions` is `envelope.baseData.properties`, not arbitrary properties on `envelope.data`. The KQL

```kusto
exceptions
| where outerMethod == "createCompileError"
| extend locale = tostring(customDimensions.locale)
| summarize cnt=count(), users=dcount(user_Id) by locale
```

returned **all 8 869 events / 902 users at `locale = ""`** — the capture was never reaching App Insights.

## Fix

Write to `envelope.baseData.properties.locale` instead, and also capture the active route via `window.location.hash` (the renderer uses `createWebHashHistory`) so the next release tells us *which screen* triggers the broken key, not just which locale. Keep `exception.locale` for back-compat in case anything else reads it from the old slot.

## What this PR does *not* do

- It does **not** fix the offending translation literal yet. We need the next release of data first.
- It does **not** add a `lint:i18n` CI gate. That belongs in `validate.yml` and will be a separate small PR once we have the locale identified.

## Verification (after next release)

```kusto
exceptions
| where application_Version startswith "0.57"
| where outerMethod == "createCompileError"
| summarize cnt=count(), users=dcount(user_Id)
        by locale = tostring(customDimensions.locale),
           route  = tostring(customDimensions.route)
| order by cnt desc
```

Expect a populated `locale` + `route` breakdown that points us straight at the offending key.

## Validation

- `pnpm --filter @xmcl/keystone-ui check` — the pre-existing `MarketTextFieldWithMenu.vue update:sort` error reproduces on `origin/master` without this patch (verified locally), so the failure is unrelated to this change.
