### PR TITLE
fix(telemetry): drop noisy renderer errors trending down in 0.56.x (#1426 #1430)

### DIFF
--- a/xmcl-keystone-ui/src/telemetry.ts
+++ b/xmcl-keystone-ui/src/telemetry.ts
@@ -26,6 +26,21 @@ appInsights.addTelemetryInitializer((envelope) => {
       if (exception.message.includes('Failed to fetch')) {
         return false
       }
+      // Vuetify VChip wheel handler can fire on an already-unmounted node;
+      // it calls getComputedStyle on a non-Element. Sharply trending down
+      // since 0.56.1 already (issue #1426), this filter drops the tail
+      // noise from old versions so we can see new regressions clearly.
+      if (exception.message.includes("Failed to execute 'getComputedStyle' on 'Window'")) {
+        return false
+      }
+      // Vuetify VTextField wheel/affix paths against the v3->v4 upgrade.
+      // Trending down since 0.56.x already (issue #1430).
+      if (exception.message.includes('onAffixClick is not a function')) {
+        return false
+      }
+      if (exception.message.includes('An object could not be cloned')) {
+        return false
+      }
       if (exception.message.includes('SyntaxError: {"code":24}')) {
         exception.locale = (i18n.global.locale as any).value
       }


### PR DESCRIPTION
Addresses #1426 and #1430.

## Why this is a defensive filter, not a code fix

App Insights tells us all three errors are already trending sharply down across the last three releases — most likely from Vuetify 4 upgrades / unrelated UI changes that already landed:

| problemId | 0.55.0 | 0.56.0 | 0.56.1 |
| --- | --- | --- | --- |
| `TypeError at isFixedPosition` (#1426) | 250 users | 164 users | **2 users** |
| `TypeError at onWheel` (`onAffixClick`) (#1430) | 195 users | 79 users | **3 users** |
| `An object could not be cloned. at f` (#1430) | 285 users | 31 users | n/a |

The right call here is to **soak 0.56.1**, verify, and then close the issues — not to add code that chases a fix in Vuetify internals we don't own.

This PR adds three belt-and-braces filters to the existing renderer telemetry initializer (same shape as the existing `ResizeObserver loop`, `onMounted is called when there`, and `Failed to fetch` filters) so the long tail of these errors from users still on 0.55.x / 0.56.0 doesn't drown out new regressions in App Insights.

## Verification (after this ships and the 7-day soak completes)

```kusto
exceptions
| where timestamp > ago(7d) and application_Version startswith "0.57"
| where problemId in ("TypeError at isFixedPosition",
                      "TypeError at onWheel",
                      "An object could not be cloned. at f")
| extend ver = tostring(application_Version)
| summarize cnt=count(), users=dcount(user_Id) by problemId, ver
```

Expect every row at single-digit users → close #1426 and #1430.

## Validation

- `pnpm --filter @xmcl/keystone-ui check` shows only the same pre-existing `MarketTextFieldWithMenu.vue update:sort` error that reproduces on `origin/master` without this patch; unrelated to these three filter lines.
