### PR TITLE
fix(keystone-ui): real fixes for #1430 from sourcemap-resolved stacks

### DIFF
--- a/xmcl-keystone-ui/src/components/MarketTextFieldWithMenu.vue
+++ b/xmcl-keystone-ui/src/components/MarketTextFieldWithMenu.vue
@@ -450,11 +450,15 @@ const sortByLocalItems = computed(() => {
 
 const chipGroup = ref(null as any)
 const onWheel = (e: WheelEvent) => {
-  if (e.deltaY > 0) {
-    chipGroup.value?.onAffixClick('next')
-  } else {
-    chipGroup.value?.onAffixClick('prev')
-  }
+  // Vuetify 4 renamed/privatized `onAffixClick` on `v-chip-group`, so the
+  // ref no longer reliably exposes a callable. Feature-detect and fall back
+  // to `scrollTo` (the documented public method) before invoking; without
+  // this guard we throw "onAffixClick is not a function" thousands of
+  // times in App Insights (issue #1430).
+  const group = chipGroup.value as { onAffixClick?: (dir: 'next' | 'prev') => void; scrollTo?: (dir: 'next' | 'prev') => void } | null
+  const handler = group?.onAffixClick ?? group?.scrollTo
+  if (typeof handler !== 'function') return
+  handler.call(group, e.deltaY > 0 ? 'next' : 'prev')
   e.preventDefault()
   e.stopPropagation()
 }

--- a/xmcl-keystone-ui/src/composables/instanceTheme.ts
+++ b/xmcl-keystone-ui/src/composables/instanceTheme.ts
@@ -34,7 +34,15 @@ export function useInstanceTheme(instancePath: Ref<string>) {
     if (!instancePath.value) return
     const theme = instanceTheme.value
     const themeData = theme ? serialize(theme) : undefined
-    await setInstanceTheme(instancePath.value, themeData)
+    // `themeData` is built from the reactive `instanceTheme.value`, so it
+    // contains nested Vue reactive proxies. Electron's IPC uses
+    // `structuredClone` under the hood and throws
+    // `An object could not be cloned.` on those proxies (issue #1430). The
+    // payload is plain JSON-shaped (`ThemeData`), so a round-trip through
+    // `JSON.parse(JSON.stringify(...))` cheaply deep-unwraps without
+    // affecting semantics.
+    const cloneable = themeData ? JSON.parse(JSON.stringify(themeData)) : undefined
+    await setInstanceTheme(instancePath.value, cloneable)
     instanceTheme.value = theme
   }
 


### PR DESCRIPTION
Fixes #1430 properly (replaces the band-aid in the now-closed #1436).

## How these were found

The renderer assets in the App Insights stacks (`VTextField-3mxf3jsm.js`, `index-BpEtaU9_.js`, …) are fingerprinted per-build, and every release uploads sourcemaps to the `sourcemap` Azure blob container. A new Deno helper in `xmcl-ops` (`scripts/resolve_telemetry_stacks.ts`) walks the container, downloads only the maps each frame needs, and resolves the minified positions back to original source. Running it against the two #1430 problemIds pointed straight at our own code:

**`TypeError at onWheel: ... onAffixClick is not a function`**
```
at onWheel (../../src/components/MarketTextFieldWithMenu.vue:456:21) [build 1306]
    original: at onWheel (http://xmcl.runtime/assets/index-BpEtaU9_.js:2:2023267)
at Wo.o.<computed>.o.<computed> (@vue/runtime-dom .../runtime-dom.esm-bundler.js:1845:11)
at callWithErrorHandling (@vue/runtime-core .../runtime-core.esm-bundler.js:199:18)
at HTMLDivElement.invoker (@vue/runtime-dom .../runtime-dom.esm-bundler.js:745:4)
```

**`An object could not be cloned. at f`**
```
at f (../../src/composables/service.ts:24:49) [build 1304]            # the IPC proxy in createProxy
at saveTheme (../../src/composables/instanceTheme.ts:37:10) [build 1304]
at toggleInstanceTheme (../../src/views/BaseSettingAppearance.vue:79:10)
```

## Fix 1 — `MarketTextFieldWithMenu.vue` wheel handler

Vuetify 4 renamed/privatized `onAffixClick` on `v-chip-group`. The existing optional chain `chipGroup.value?.onAffixClick('prev')` only guards against the ref itself being null, not against the resolved object lacking the method, so we throw `is not a function`. Feature-detect both `onAffixClick` (legacy) and `scrollTo` (the documented public method) and silently skip the wheel scroll when neither is available. No behavioral regression for users on a Vuetify version that still exposes the method.

## Fix 2 — `instanceTheme.ts:saveTheme`

`themeData` is built from the reactive `instanceTheme.value`, so it carries nested Vue reactive proxies. Electron IPC uses `structuredClone` and throws `An object could not be cloned.` on those proxies. `ThemeData` is plain JSON-shaped (it serializes through to Cosmos / disk), so a `JSON.parse(JSON.stringify(...))` round-trip in the caller cheaply deep-unwraps the payload before it crosses the boundary. Doing it here (rather than in the generic IPC proxy in `service.ts`) keeps File/Blob-carrying services untouched.

## Out of scope

`TypeError at isFixedPosition` (#1426) resolved to pure Vuetify upstream (`lib/util/isFixedPosition.js:3`) — not our code. It's already trending to ~2 users on 0.56.1 so a Vuetify upgrade in a future PR is the proper fix; nothing to land here.

## Verification (after next release)

```kusto
exceptions
| where application_Version startswith "0.57"
| where problemId in ("TypeError at onWheel",
                      "An object could not be cloned. at f")
| summarize cnt=count(), users=dcount(user_Id) by problemId
```

Expect both problemIds to drop sharply and stay flat across later versions.

## Validation

- `pnpm --filter @xmcl/keystone-ui check` — only the pre-existing `MarketTextFieldWithMenu.vue update:sort` overload error reproduces on `origin/master` without this patch (unrelated to the lines this PR touches).
