### PR TITLE
fix(telemetry): batch P2 fixes (CurseForge / Mojang / MS XErr / stream controller / Modrinth deps)

### DIFF
--- a/packages/curseforge/index.ts
+++ b/packages/curseforge/index.ts
@@ -816,6 +816,19 @@ export class CurseforgeV1Client {
     fingerprints: number[],
     signal?: AbortSignal,
   ) {
+    if (!fingerprints || fingerprints.length === 0) {
+      // CurseForge rejects empty arrays with HTTP 400 "Fingerprints are required.".
+      // Short-circuit instead of burning a request + API quota (see issue #1443).
+      const empty: FingerprintsMatchesResult['data'] = {
+        isCacheBuilt: false,
+        exactMatches: [],
+        exactFingerprints: [],
+        partialMatches: [],
+        partialFingerprints: {},
+        unmatchedFingerprints: [],
+      }
+      return empty
+    }
     const url = new URL(this.baseUrl + `/v1/fingerprints/${gameId}`)
     const response = await this.fetch(url, {
       method: 'POST',
@@ -839,6 +852,17 @@ export class CurseforgeV1Client {
     fingerprints: number[],
     signal?: AbortSignal,
   ) {
+    if (!fingerprints || fingerprints.length === 0) {
+      const empty: FingerprintsMatchesResult['data'] = {
+        isCacheBuilt: false,
+        exactMatches: [],
+        exactFingerprints: [],
+        partialMatches: [],
+        partialFingerprints: {},
+        unmatchedFingerprints: [],
+      }
+      return empty
+    }
     const url = new URL(this.baseUrl + `/v1/fingerprints/fuzzy/${gameId}`)
     const response = await this.fetch(url, {
       method: 'POST',

--- a/packages/user/microsoft.test.ts
+++ b/packages/user/microsoft.test.ts
@@ -1,6 +1,6 @@
 import { MockAgent, fetch as _fetch } from 'undici'
 import { describe, expect, it } from 'vitest'
-import { MicrosoftAuthenticator } from './microsoft'
+import { MicrosoftAuthenticator, MicrosoftMinecraftXboxLoginError } from './microsoft'
 
 describe('MicrosoftAuthenticator', () => {
   const agent = new MockAgent()
@@ -68,5 +68,46 @@ describe('MicrosoftAuthenticator', () => {
 
     // Assert
     expect(result.Token).to.equal(expectedToken)
+  })
+
+  describe('#loginMinecraftWithXBox', () => {
+    it('throws MicrosoftMinecraftXboxLoginError with status + body for a non-200 response', async () => {
+      const pool = agent.get('https://api.minecraftservices.com')
+      pool
+        .intercept({
+          method: 'POST',
+          path: '/authentication/login_with_xbox',
+        })
+        .reply(401, 'unauthorized body')
+
+      const client = new MicrosoftAuthenticator({ fetch })
+      await expect(client.loginMinecraftWithXBox('uhs', 'xsts')).rejects.toMatchObject({
+        name: 'MicrosoftMinecraftXboxLoginError',
+        status: 401,
+        body: 'unauthorized body',
+        retryable: false,
+      })
+    })
+
+    it('parses Retry-After (seconds) into retryAfter ms and marks 429 retryable', async () => {
+      const pool = agent.get('https://api.minecraftservices.com')
+      pool
+        .intercept({
+          method: 'POST',
+          path: '/authentication/login_with_xbox',
+        })
+        .reply(429, '', { headers: { 'retry-after': '2' } })
+
+      const client = new MicrosoftAuthenticator({ fetch })
+      try {
+        await client.loginMinecraftWithXBox('uhs', 'xsts')
+        throw new Error('expected throw')
+      } catch (e: any) {
+        expect(e).toBeInstanceOf(MicrosoftMinecraftXboxLoginError)
+        expect(e.status).toBe(429)
+        expect(e.retryable).toBe(true)
+        expect(e.retryAfter).toBe(2000)
+      }
+    })
   })
 })

--- a/packages/user/microsoft.ts
+++ b/packages/user/microsoft.ts
@@ -54,13 +54,41 @@ export interface MicrosoftAuthenticatorOptions {
 }
 
 /**
+  * Thrown by {@link MicrosoftAuthenticator.loginMinecraftWithXBox} when the
+  * Minecraft auth endpoint returns a non-200 response. Carries enough
+  * context that the launcher can tell the user *exactly* what went wrong
+  * instead of a generic "loginMinecraftByXboxFailed" (see issue #1445).
+  *
+  * Retry semantics (for 408/425/429/5xx) are intentionally out of scope of
+  * this module -- compose them on the caller side by wrapping the injected
+  * `fetch` (see ``xmcl-runtime/user/utils/withRetry.ts`` in the launcher).
+  */
+export class MicrosoftMinecraftXboxLoginError extends Error {
+  name = 'MicrosoftMinecraftXboxLoginError'
+  constructor(
+    public status: number,
+    public body: string,
+    /** Effective Retry-After in ms from the response header, if any. */
+    public retryAfter?: number,
+    /**
+     * True when the status is in the transient set a retrying client would
+     * normally retry (408/425/429/5xx). Useful to tell the user "try again
+     * in a moment" vs. "this is a permanent error".
+     */
+    public retryable?: boolean,
+  ) {
+    super(`Failed to login minecraft with xbox, status code: ${status}: ${body}}`)
+  }
+}
+
+/**
  * The microsoft authenticator for Minecraft (Xbox) account.
  */
 export class MicrosoftAuthenticator {
   fetch: typeof fetch
 
-  constructor(options: MicrosoftAuthenticatorOptions) {
-    this.fetch = options.fetch || fetch
+  constructor(options?: MicrosoftAuthenticatorOptions) {
+    this.fetch = options?.fetch || fetch
   }
 
   /**
@@ -214,6 +242,18 @@ export class MicrosoftAuthenticator {
    * @param uhs uhs from {@link XBoxResponse} of {@link acquireXBoxToken}
    * @param xstsToken You need to get this token from {@link acquireXBoxToken}
    */
+  /**
+    * Login Minecraft with an Xbox token. This method does exactly one HTTP
+    * attempt -- if you need retry/backoff for transient failures (408, 425,
+    * 429, 5xx), compose it on the caller side by wrapping the `fetch` you
+    * inject into this authenticator. On any non-200 the method throws a
+    * {@link MicrosoftMinecraftXboxLoginError} that carries `status`,
+    * `body`, parsed `retryAfter` (ms) and a `retryable` flag so the UI can
+    * surface a precise message (see issue #1445).
+    *
+    * @param uhs uhs from {@link XBoxResponse} of {@link acquireXBoxToken}
+    * @param xstsToken You need to get this token from {@link acquireXBoxToken}
+    */
   async loginMinecraftWithXBox(uhs: string, xstsToken: string, signal?: AbortSignal) {
     const mcResponse = await this.fetch(
       'https://api.minecraftservices.com/authentication/login_with_xbox',
@@ -229,14 +269,33 @@ export class MicrosoftAuthenticator {
       },
     )
 
-    if (mcResponse.status !== 200) {
-      throw new Error(
-        `Failed to login minecraft with xbox, status code: ${mcResponse.status}: ${await mcResponse.text()}}`,
-      )
+    if (mcResponse.status === 200) {
+      return (await mcResponse.json()) as MinecraftAuthResponse
     }
 
-    const result = (await mcResponse.json()) as MinecraftAuthResponse
+    const transientStatuses = new Set([408, 425, 429, 500, 502, 503, 504])
+    const body = await mcResponse.text()
+    // Parse Retry-After (seconds or HTTP-date) so the UI can show a sensible
+    // wait hint when the caller's retry budget has been exhausted.
+    let retryAfterMs: number | undefined
+    const retryAfter = mcResponse.headers.get('retry-after')
+    if (retryAfter) {
+      const asInt = parseInt(retryAfter, 10)
+      if (!Number.isNaN(asInt)) {
+        retryAfterMs = asInt * 1000
+      } else {
+        const dateMs = Date.parse(retryAfter)
+        if (!Number.isNaN(dateMs)) {
+          retryAfterMs = Math.max(0, dateMs - Date.now())
+        }
+      }
+    }
 
-    return result
+    throw new MicrosoftMinecraftXboxLoginError(
+      mcResponse.status,
+      body,
+      retryAfterMs,
+      transientStatuses.has(mcResponse.status),
+    )
   }
 }

--- a/xmcl-electron-app/main/ElectronSession.ts
+++ b/xmcl-electron-app/main/ElectronSession.ts
@@ -89,11 +89,23 @@ export class ElectronSession {
         headers[key] = value
       })
 
+      const adaptRequestBody = () => {
+        if (!request.body) return undefined
+        const readable = Readable.fromWeb(request.body as any)
+        readable.on('error', (err: any) => {
+          if (err && (err.code === 'ERR_INVALID_STATE' || err.message === 'Invalid state: Controller is already closed')) {
+            return
+          }
+          readable.destroy(err)
+        })
+        return readable
+      }
+
       const response = await this.app.protocol.handle({
         url: new URL(url),
         method: request.method,
         headers: headers,
-        body: request.body ? Readable.fromWeb(request.body as any) : request.body as any,
+        body: adaptRequestBody() as any,
       })
 
       response.headers['access-control-allow-origin'] = ['*']

--- a/xmcl-electron-app/main/controllers/optifine.ts
+++ b/xmcl-electron-app/main/controllers/optifine.ts
@@ -9,6 +9,20 @@ import { kOptifineInstaller } from '~/install'
 import { kSettings, shouldOverrideApiSet } from '~/settings'
 import { ControllerPlugin } from './plugin'
 
+// See xmcl-runtime/app/pluginCommonProtocol.ts — same rationale for
+// silencing ERR_INVALID_STATE on aborted upstream fetches (issue #1446).
+const adaptWebBody = (body: ReadableStream | Readable | null | undefined) => {
+  if (!(body instanceof ReadableStream)) return body ?? undefined
+  const readable = Readable.fromWeb(body as any)
+  readable.on('error', (err: any) => {
+    if (err && (err.code === 'ERR_INVALID_STATE' || err.message === 'Invalid state: Controller is already closed')) {
+      return
+    }
+    readable.destroy(err)
+  })
+  return readable
+}
+
 export const optifine: ControllerPlugin = async function (this: ElectronController) {
   let pooled: BrowserWindow | undefined
   let clearTimeout: AbortController | undefined
@@ -142,19 +156,13 @@ export const optifine: ControllerPlugin = async function (this: ElectronControll
         if (resp.ok) {
           ctx.response.status = resp.status
           ctx.response.headers = resp.headers
-          ctx.response.body =
-            resp.body instanceof ReadableStream
-              ? Readable.fromWeb(resp.body as any)
-              : (resp.body ?? undefined)
+          ctx.response.body = adaptWebBody(resp.body as any)
         } else {
           const result = await Promise.race([getDownloads(), setTimeout(5000)])
           if (!result) {
             ctx.response.status = resp.status
             ctx.response.headers = resp.headers
-            ctx.response.body =
-              resp.body instanceof ReadableStream
-                ? Readable.fromWeb(resp.body as any)
-                : (resp.body ?? undefined)
+            ctx.response.body = adaptWebBody(resp.body as any)
           } else {
             ctx.response.status = 200
             ctx.response.headers = {

--- a/xmcl-keystone-ui/locales/en.yaml
+++ b/xmcl-keystone-ui/locales/en.yaml
@@ -610,10 +610,32 @@ loginError:
   invalidCredentials: Invalid credentials. Invalid username or password.
   loginMinecraftByXboxFailed: >-
     Fail to exchange Minecraft token by Xbox token. Please make sure you have Minecraft in Xbox, or retry.
+  loginMinecraftByXboxRateLimited: >-
+    Microsoft's Minecraft authentication service is currently rate-limiting requests (HTTP 429). Please wait a moment and try again.
+  loginMinecraftByXboxRateLimitedWithRetry: >-
+    Microsoft's Minecraft authentication service is currently rate-limiting requests (HTTP 429). Please wait about {seconds} second(s) and try again.
+  loginMinecraftByXboxServerError: >-
+    Microsoft's Minecraft authentication service returned a server error (HTTP {status}). This is on their side. Please try again in a few minutes.
+  loginMinecraftByXboxStatus: >-
+    Fail to exchange Minecraft token by Xbox token (HTTP {status}). Please make sure you have Minecraft in Xbox, or retry.
   loginXboxAgeRestricted: >-
     Fail to login Xbox due the the age issue. Please make sure the age is set for your Microsoft account and the age is above 18.
+  loginXboxChildAccount: >-
+    Your Microsoft account is a child account and needs to be added to a Microsoft Family before it can sign in to Xbox / Minecraft. Open {url} in your browser to fix it, then try again.
+  loginXboxNoXboxProfile: >-
+    This Microsoft account does not have an Xbox profile yet. Open {url} in your browser to create one, then try again.
+  loginXboxAdultVerification: >-
+    Your Microsoft account requires adult verification (commonly required in some regions) before it can sign in to Xbox. Open {url} in your browser to complete verification, then try again.
+  loginXboxRegionLocked: >-
+    Xbox Live is not available in your account's region. Please change your Microsoft account's country/region in Microsoft account settings and try again.
+  loginXboxBanned: >-
+    This Microsoft / Xbox account has been suspended or banned by Microsoft and cannot sign in to Minecraft. Please contact Microsoft / Xbox support.
+  loginXboxBadXsts: >-
+    Microsoft returned an XSTS response without the expected user claims. This is usually temporary -- please try again in a few minutes.
   loginXboxFailed: >-
     Fail to login Xbox by Microsoft token. Please make sure you have an independent Xbox account to your Microsoft account. Please try again.
+  loginXboxFailedWithCode: >-
+    Fail to login Xbox by Microsoft token (XErr {code}). Please search the code for help, or try again later.
   noProfileForNewUser: >-
     No game profile found! If you are a new Minecraft user, please login at least one time in Minecraft official launcher.
   requestFailed: Login failed, we do not know the exact reason. Please retry.

--- a/xmcl-keystone-ui/locales/zh-CN.yaml
+++ b/xmcl-keystone-ui/locales/zh-CN.yaml
@@ -611,10 +611,21 @@ loginError:
   illegalEmail: 当前的邮箱格式不合法
   invalidCredentials: 无法验证。用户名或密码错误。
   loginMinecraftByXboxFailed: 在通过 Xbox 通证交换 Minecraft 通证的过程中发生错误，请确认您的 Xbox 账号拥有 Minecraft。您可以尝试重试登录
+  loginMinecraftByXboxRateLimited: 微软的 Minecraft 登录服务当前正在限流（HTTP 429），请稍等片刻后重试。
+  loginMinecraftByXboxRateLimitedWithRetry: 微软的 Minecraft 登录服务当前正在限流（HTTP 429），请等待约 {seconds} 秒后重试。
+  loginMinecraftByXboxServerError: 微软的 Minecraft 登录服务返回了服务器错误（HTTP {status}），这是微软那边的问题，请稍后几分钟再试。
+  loginMinecraftByXboxStatus: '通过 Xbox 通证交换 Minecraft 通证失败（HTTP {status}），请确认您的 Xbox 账号拥有 Minecraft，或稍后重试。'
   loginXboxAgeRestricted: |-
     由于年龄问题，无法登录Xbox。
     请确保为您的Microsoft帐户设定年龄，并且年龄高于18岁。
+  loginXboxChildAccount: '您的微软账号是儿童账号，需要先在 Microsoft 家庭中被添加为家庭成员才能登录 Xbox / Minecraft。请在浏览器中打开 {url} 完成设置后重试。'
+  loginXboxNoXboxProfile: '该微软账号还没有 Xbox 档案。请在浏览器中打开 {url} 创建一个 Xbox 档案后重试。'
+  loginXboxAdultVerification: '您的微软账号需要先完成成人身份验证（部分地区强制要求）才能登录 Xbox。请在浏览器中打开 {url} 完成验证后重试。'
+  loginXboxRegionLocked: Xbox Live 在您账号所在的国家/地区不可用。请到微软账号设置中修改账号的国家/地区后重试。
+  loginXboxBanned: 该微软 / Xbox 账号已被微软封禁或暂停使用，无法登录 Minecraft。请联系微软 / Xbox 客服。
+  loginXboxBadXsts: 微软返回的 XSTS 响应缺少用户身份信息。这通常是临时问题，请稍后几分钟再试。
   loginXboxFailed: 请求 Xbox 通证失败，请确保您的微软账号已经绑定了一个 Xbox 账号！
+  loginXboxFailedWithCode: '请求 Xbox 通证失败（XErr {code}），请根据该错误码搜索解决方案，或稍后重试。'
   noProfileForNewUser: |-
     找不到游戏资料！
     如果您是新的Minecraft用户，请在Minecraft官方启动器中至少登录一次。

--- a/xmcl-keystone-ui/src/components/UserLoginForm.vue
+++ b/xmcl-keystone-ui/src/components/UserLoginForm.vue
@@ -359,12 +359,49 @@ const errorMessage = computed(() => {
       return t('loginError.checkOwnershipFailed')
     }
     if (e.exception.type === 'userExchangeXboxTokenFailed') {
-      if (e.exception.reason === 'BAD_AGE') {
-        return t('loginError.loginXboxAgeRestricted')
+      const redirect = e.exception.xErrRedirect
+      // New granular reasons take precedence; legacy reasons fall through
+      // to the existing strings. Where Microsoft returns a fix-it URL
+      // (e.g. AddChildToFamily, CreateAccount), pass it through so the
+      // user can click straight to the resolution.
+      switch (e.exception.reason) {
+        case 'CHILD_ACCOUNT':
+          return t('loginError.loginXboxChildAccount', { url: redirect ?? 'https://start.ui.xboxlive.com/AddChildToFamily' })
+        case 'NO_XBOX_PROFILE':
+        case 'NO_ACCOUNT':
+          return t('loginError.loginXboxNoXboxProfile', { url: redirect ?? 'https://start.ui.xboxlive.com/CreateAccount' })
+        case 'ADULT_VERIFICATION_REQUIRED':
+          return t('loginError.loginXboxAdultVerification', { url: redirect ?? '' })
+        case 'REGION_LOCKED':
+          return t('loginError.loginXboxRegionLocked')
+        case 'BANNED':
+          return t('loginError.loginXboxBanned')
+        case 'BAD_AGE':
+          return t('loginError.loginXboxAgeRestricted')
+        case 'BAD_XSTS':
+          return t('loginError.loginXboxBadXsts')
+      }
+      // Surface the raw XErr code if we have one but no classification --
+      // helps users searching the web / opening support tickets.
+      if (typeof e.exception.xErr === 'number') {
+        return t('loginError.loginXboxFailedWithCode', { code: e.exception.xErr })
       }
       return t('loginError.loginXboxFailed')
     }
     if (e.exception.type === 'userLoginMinecraftByXboxFailed') {
+      const { status, retryAfter } = e.exception
+      if (status === 429) {
+        const retrySeconds = typeof retryAfter === 'number' ? Math.ceil(retryAfter / 1000) : undefined
+        return retrySeconds
+          ? t('loginError.loginMinecraftByXboxRateLimitedWithRetry', { seconds: retrySeconds })
+          : t('loginError.loginMinecraftByXboxRateLimited')
+      }
+      if (typeof status === 'number' && status >= 500) {
+        return t('loginError.loginMinecraftByXboxServerError', { status })
+      }
+      if (typeof status === 'number') {
+        return t('loginError.loginMinecraftByXboxStatus', { status })
+      }
       return t('loginError.loginMinecraftByXboxFailed')
     }
     if (e.exception.type === 'loginReset') {

--- a/xmcl-keystone-ui/src/composables/modrinthDependencies.ts
+++ b/xmcl-keystone-ui/src/composables/modrinthDependencies.ts
@@ -43,7 +43,18 @@ const visit = async (current: ResolvedDependency, visited: Set<string>, config: 
         config.cache!, config.dedupingInterval!)
       const recommendedVersion = child.version_id ? versions.find(v => v.id === child.version_id) ?? versions[0] : versions[0]
       if (!recommendedVersion) {
-        throw new TypeError(`Missing ${child.project_id}:${child.version_id} during resolve modrinth deps of ${version.project_id}:${version.id}`)
+        // Issue #1444: Modrinth allows `version_id: null` on a dependency
+        // ("any compatible version"); if our compatibility filter
+        // (loader + game version) returns nothing, we have no concrete
+        // version to install. For non-required deps this is benign --
+        // skip silently. For required deps, log a single warn so the UI
+        // can still surface the parent project; don't throw, otherwise
+        // one missing edge fails the entire dependency tree fetch.
+        if (child.dependency_type !== 'required') {
+          return []
+        }
+        console.warn(`[modrinth deps] No compatible version of ${child.project_id} (requested ${child.version_id ?? 'any'}) for ${version.project_id}:${version.id} on loaders=${JSON.stringify(loaders)} mc=${JSON.stringify(version.game_versions)} -- skipping`)
+        return []
       }
       const result = await visit(markRaw({
         project,

--- a/xmcl-runtime-api/src/services/UserService.ts
+++ b/xmcl-runtime-api/src/services/UserService.ts
@@ -254,9 +254,37 @@ export type UserExceptions = {
   type: 'userAcquireMicrosoftTokenFailed'
 } | {
   type: 'userExchangeXboxTokenFailed'
+  /**
+    * The classified reason for the failure. New granular reasons were added
+    * for issue #1445 so the UI can show the user what exactly went wrong
+    * (and, where applicable, deep-link the Microsoft fix-it URL via
+    * {@link xErrRedirect}). `NO_ACCOUNT` / `BAD_AGE` / `BAD_XSTS` are kept
+    * for backwards compatibility with older renderers.
+    */
   reason?: 'NO_ACCOUNT' | 'BAD_AGE' | 'BAD_XSTS'
+    | 'NO_XBOX_PROFILE'
+    | 'CHILD_ACCOUNT'
+    | 'ADULT_VERIFICATION_REQUIRED'
+    | 'REGION_LOCKED'
+    | 'BANNED'
+    | 'RATE_LIMITED'
+    | 'TIMEOUT'
+  /** Raw XErr code from the XSTS /authorize 401 body, if any. */
+  xErr?: number
+  /** The Message field from the XErr body (often empty). */
+  xErrMessage?: string
+  /** The Redirect URL Microsoft returns alongside the XErr (e.g. AddChildToFamily, CreateAccount). */
+  xErrRedirect?: string
 } | {
   type: 'userLoginMinecraftByXboxFailed'
+  /** HTTP status code from /authentication/login_with_xbox, if available. */
+  status?: number
+  /** Raw response body (truncated by the catch site) — useful when debugging. */
+  statusBody?: string
+  /** Whether the failure was a transient HTTP code retried by the client. */
+  retryable?: boolean
+  /** Effective Retry-After (ms) the server asked us to wait, if any. */
+  retryAfter?: number
 } | {
   type: 'userCheckGameOwnershipFailed'
 } | {

--- a/xmcl-runtime/app/pluginCommonProtocol.ts
+++ b/xmcl-runtime/app/pluginCommonProtocol.ts
@@ -3,6 +3,29 @@ import type { LauncherAppPlugin } from './LauncherAppPlugin'
 import type { Handler } from './LauncherProtocolHandler'
 
 /**
+ * Convert a WHATWG ReadableStream into a Node Readable while silently
+ * swallowing ERR_INVALID_STATE "Controller is already closed". That error
+ * fires when the underlying fetch is aborted (user navigated away, window
+ * closed, request cancelled) and a late chunk tries to enqueue into a
+ * stream the consumer has already torn down — benign, but produces a noisy
+ * trackException because the minified async stack is unidentifiable
+ * (see issue #1446).
+ */
+const adaptWebBody = (body: ReadableStream | Readable | null | undefined) => {
+  if (!(body instanceof ReadableStream)) return body ?? undefined
+  const readable = Readable.fromWeb(body as any)
+  readable.on('error', (err: any) => {
+    if (err && (err.code === 'ERR_INVALID_STATE' || err.message === 'Invalid state: Controller is already closed')) {
+      // Already-closed controller — consumer is gone, drop quietly.
+      return
+    }
+    // Re-emit non-benign errors so the protocol handler still surfaces them.
+    readable.destroy(err)
+  })
+  return readable
+}
+
+/**
  * The plugin to handle all fallback http request
  */
 export const pluginCommonProtocol: LauncherAppPlugin = (app) => {
@@ -21,7 +44,7 @@ export const pluginCommonProtocol: LauncherAppPlugin = (app) => {
       })
       response.status = resp.status
       response.headers = resp.headers
-      response.body = resp.body instanceof ReadableStream ? Readable.fromWeb(resp.body as any) : (resp.body ?? undefined)
+      response.body = adaptWebBody(resp.body as any)
     } catch (e) {
       throw e
     }

--- a/xmcl-runtime/infra/errors/ErrorDiagnose.ts
+++ b/xmcl-runtime/infra/errors/ErrorDiagnose.ts
@@ -66,6 +66,23 @@ export class ErrorDiagnose {
     if (e.name === 'ClientAuthError' && e.message.includes('Network request failed')) {
       return true
     }
+    // Issue #1442: 404 from /minecraft/profile just means the user's MS
+    // account doesn't own Minecraft. The login flow now wraps it in a
+    // UserException, but suppress it here too in case any future caller
+    // forgets and bubbles the raw error through logEmitter('failure').
+    if (e.name === 'ProfileNotFoundError') {
+      return true
+    }
+    // Issue #1446: Node WHATWG streams throw ERR_INVALID_STATE
+    // "Controller is already closed" when a ReadableStream we wrap around
+    // an aborted/closed fetch tries to enqueue a late chunk. This is
+    // benign — the consumer is already gone. The renderer/keystone
+    // protocol handlers now guard against it, but suppress here as the
+    // last line of defense (minified async stacks make the call site
+    // unidentifiable anyway).
+    if (e instanceof TypeError && (e as any).code === 'ERR_INVALID_STATE') {
+      return true
+    }
     return false
   }
 }

--- a/xmcl-runtime/user/accountSystems/MicrosoftAccountSystem.ts
+++ b/xmcl-runtime/user/accountSystems/MicrosoftAccountSystem.ts
@@ -1,5 +1,5 @@
 import { AUTHORITY_MICROSOFT, AuthorityMetadata, GameProfileAndTexture, LoginOptions, RefreshUserOptions, Skin, SkinPayload, UserException, UserProfile, normalizeUserId } from '@xmcl/runtime-api'
-import { MicrosoftAuthenticator, MicrosoftMinecraftProfile, MojangClient, MojangError } from '@xmcl/user'
+import { MicrosoftAuthenticator, MicrosoftMinecraftProfile, MicrosoftMinecraftXboxLoginError, MojangClient, MojangError } from '@xmcl/user'
 import { randomUUID } from 'crypto'
 import { LauncherApp } from '~/app'
 import { Logger } from '~/infra'
@@ -157,30 +157,39 @@ export class MicrosoftAccountSystem implements UserAccountSystem {
   }
 
   protected async loginMicrosoft(microsoftEmailAddress: string, oauthCode: string | undefined, useDeviceCode: boolean, directRedirectToLauncher: boolean, signal: AbortSignal, slientOnly = false) {
-    // XErr codes from XSTS /authorize that are "user state, not a bug" — child
-    // account, missing Xbox profile, age/region issues. See issue #1445. We
-    // still throw a UserException so the UI can deep-link the user to the fix,
-    // but we don't surface these as telemetry exceptions (they are not
-    // actionable for us as developers).
-    const knownXErrCodes = new Set([
-      2148916233, // No Xbox profile — must create one
-      2148916235, // Region locked
-      2148916236, // Adult verification required
-      2148916237, // Adult verification required
-      2148916238, // Child account — must be added to Microsoft Family
-      2148916227, // Banned
-    ])
+    // XErr codes from XSTS /authorize that are "user state, not a bug" --
+    // child account, missing Xbox profile, age/region issues, banned, etc.
+    // See issue #1445. We still throw a UserException so the UI can deep-link
+    // the user to the fix (xErrRedirect), but we don't surface these as
+    // telemetry exceptions (they are not actionable for us as developers).
+    //
+    // XErr code -> classified reason for the UI. Mapped from
+    // https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/reference/system/xstsruntimes/enums/xsts_token_error_code
+    // and observed App Insights samples.
+    const xErrReasonMap: Record<number, NonNullable<Extract<UserException['exception'], { type: 'userExchangeXboxTokenFailed' }>['reason']>> = {
+      2148916227: 'BANNED',                       // Account is banned
+      2148916233: 'NO_XBOX_PROFILE',              // No Xbox profile -- must create one (redirect: CreateAccount)
+      2148916235: 'REGION_LOCKED',                // Xbox Live not available in the user's region
+      2148916236: 'ADULT_VERIFICATION_REQUIRED',  // Adult verification required (KR)
+      2148916237: 'ADULT_VERIFICATION_REQUIRED',  // Adult verification required (KR)
+      2148916238: 'CHILD_ACCOUNT',                // Child account -- must be added to Microsoft Family (redirect: AddChildToFamily)
+    }
+    const knownXErrCodes = new Set(Object.keys(xErrReasonMap).map(Number))
     const isKnownXErr = (e: any) => typeof e?.XErr !== 'undefined' && knownXErrCodes.has(Number(e.XErr))
     const isExpectedAuthFailure = (e: any) => {
       if (!e) return false
       if (e.name === 'AbortError') return true
       // ProfileNotFoundError just means "this MS account doesn't own
-      // Minecraft" — expected, see issue #1442.
+      // Minecraft" -- expected, see issue #1442.
       if (e.name === 'ProfileNotFoundError') return true
       if (isKnownXErr(e)) return true
-      // 429 from login_with_xbox is transient + retried below; don't drown
-      // telemetry with it. The microsoft.ts retry path already swallows
-      // transient cases before they reach us.
+      // 429/408 from login_with_xbox is transient. When the authenticator
+      // uses its built-in undici fetch + RetryAgent, undici retries it
+      // before we ever see it. When the caller injected its own fetch (e.g.
+      // the launcher passes Electron's net.fetch in pluginOfficialUserApi),
+      // there is no retry and we'll see the raw status here -- still treat
+      // it as expected/transient so it doesn't pollute telemetry.
+      if (e instanceof MicrosoftMinecraftXboxLoginError && e.retryable) return true
       if (typeof e?.message === 'string' && /status code: (?:408|429)/.test(e.message)) return true
       return false
     }
@@ -214,7 +223,23 @@ export class MicrosoftAccountSystem implements UserAccountSystem {
     const { liveXstsResponse, minecraftXstsResponse } = await this.authenticator.acquireXBoxToken(oauthAccessToken, signal).catch((e) => {
       logError(e)
       const xErr = Number(e.XErr)
-      throw new UserException({ type: 'userExchangeXboxTokenFailed', reason: xErr === 2148916233 ? 'NO_ACCOUNT' : [2148916238, 2148916236, 2148916227].includes(xErr) ? 'BAD_AGE' : undefined }, 'Failed to exchange Xbox token', { cause: e })
+      const reason = xErrReasonMap[xErr]
+      // Preserve the legacy `NO_ACCOUNT` / `BAD_AGE` reasons so older UI
+      // builds still pick the right friendly message while the new
+      // granular reasons drive the new code paths.
+      const legacyReason: 'NO_ACCOUNT' | 'BAD_AGE' | undefined =
+        reason === 'NO_XBOX_PROFILE'
+          ? 'NO_ACCOUNT'
+          : (reason === 'CHILD_ACCOUNT' || reason === 'ADULT_VERIFICATION_REQUIRED' || reason === 'BANNED')
+              ? 'BAD_AGE'
+              : undefined
+      throw new UserException({
+        type: 'userExchangeXboxTokenFailed',
+        reason: reason ?? legacyReason,
+        xErr: Number.isFinite(xErr) ? xErr : undefined,
+        xErrMessage: typeof e?.Message === 'string' ? e.Message : undefined,
+        xErrRedirect: typeof e?.Redirect === 'string' ? e.Redirect : undefined,
+      }, 'Failed to exchange Xbox token', { cause: e })
     })
 
     const aquireAccessToken = async (xstsResponse: XBoxResponse) => {
@@ -226,6 +251,18 @@ export class MicrosoftAccountSystem implements UserAccountSystem {
 
       const mcResponse = await this.authenticator.loginMinecraftWithXBox(xstsResponse.DisplayClaims.xui[0].uhs, xstsResponse.Token, signal).catch((e) => {
         logError(e)
+        if (e instanceof MicrosoftMinecraftXboxLoginError) {
+          // Truncate the raw body so it stays useful in UI tooltips but
+          // doesn't blow up the exception payload.
+          const truncatedBody = typeof e.body === 'string' ? e.body.slice(0, 512) : undefined
+          throw new UserException({
+            type: 'userLoginMinecraftByXboxFailed',
+            status: e.status,
+            statusBody: truncatedBody,
+            retryable: e.retryable,
+            retryAfter: e.retryAfter,
+          }, `Failed to login Minecraft with Xbox (HTTP ${e.status})`, { cause: e })
+        }
         throw new UserException({ type: 'userLoginMinecraftByXboxFailed' }, 'Failed to login Minecraft with Xbox', { cause: e })
       })
       this.logger.log('Successfully login Minecraft with Xbox')

--- a/xmcl-runtime/user/accountSystems/MicrosoftAccountSystem.ts
+++ b/xmcl-runtime/user/accountSystems/MicrosoftAccountSystem.ts
@@ -157,8 +157,38 @@ export class MicrosoftAccountSystem implements UserAccountSystem {
   }
 
   protected async loginMicrosoft(microsoftEmailAddress: string, oauthCode: string | undefined, useDeviceCode: boolean, directRedirectToLauncher: boolean, signal: AbortSignal, slientOnly = false) {
+    // XErr codes from XSTS /authorize that are "user state, not a bug" — child
+    // account, missing Xbox profile, age/region issues. See issue #1445. We
+    // still throw a UserException so the UI can deep-link the user to the fix,
+    // but we don't surface these as telemetry exceptions (they are not
+    // actionable for us as developers).
+    const knownXErrCodes = new Set([
+      2148916233, // No Xbox profile — must create one
+      2148916235, // Region locked
+      2148916236, // Adult verification required
+      2148916237, // Adult verification required
+      2148916238, // Child account — must be added to Microsoft Family
+      2148916227, // Banned
+    ])
+    const isKnownXErr = (e: any) => typeof e?.XErr !== 'undefined' && knownXErrCodes.has(Number(e.XErr))
+    const isExpectedAuthFailure = (e: any) => {
+      if (!e) return false
+      if (e.name === 'AbortError') return true
+      // ProfileNotFoundError just means "this MS account doesn't own
+      // Minecraft" — expected, see issue #1442.
+      if (e.name === 'ProfileNotFoundError') return true
+      if (isKnownXErr(e)) return true
+      // 429 from login_with_xbox is transient + retried below; don't drown
+      // telemetry with it. The microsoft.ts retry path already swallows
+      // transient cases before they reach us.
+      if (typeof e?.message === 'string' && /status code: (?:408|429)/.test(e.message)) return true
+      return false
+    }
     const logError = (e: any) => {
-      if (e.name === 'AbortError') {
+      if (isExpectedAuthFailure(e)) {
+        // Still want a local log line for the user / dev tools, but route it
+        // through warn so it never reaches trackException.
+        this.logger.warn(Object.assign(e, { scenario: 'loginMicrosoft', expected: true }))
         return
       }
       if (e.name === 'Error') {

--- a/xmcl-runtime/user/pluginOfficialUserApi.ts
+++ b/xmcl-runtime/user/pluginOfficialUserApi.ts
@@ -7,6 +7,7 @@ import { UserService } from './UserService'
 import { MicrosoftAccountSystem } from './accountSystems/MicrosoftAccountSystem'
 import { MicrosoftOAuthClient } from './accountSystems/MicrosoftOAuthClient'
 import { kUserTokenStorage } from './userTokenStore'
+import { withRetry } from './utils/withRetry'
 
 const CLIENT_ID = '1363d629-5b06-48a9-a5fb-c65de945f13e'
 
@@ -24,8 +25,13 @@ export const pluginOfficialUserApi: LauncherAppPlugin = async (app) => {
   const headers = {}
 
   const system = new MicrosoftAccountSystem(logger,
+    // app.fetch resolves to Electron's net.fetch (with an undici fallback)
+    // -- neither path applies retry interceptors. Compose retry on top via
+    // withRetry() so that 408/425/429/5xx from Microsoft endpoints are
+    // retried with Retry-After honored, regardless of which underlying
+    // HTTP stack handles the call. See issue #1445 / PR #1447.
     new MicrosoftAuthenticator({
-      fetch: (...args) => app.fetch(...args),
+      fetch: withRetry((...args) => app.fetch(...args)),
     }),
     mojangApi,
     () => app.registry.get(kUserTokenStorage),

--- a/xmcl-runtime/user/utils/withRetry.test.ts
+++ b/xmcl-runtime/user/utils/withRetry.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import { withRetry } from './withRetry'
+
+const ok = (status: number, headers: Record<string, string> = {}) =>
+  new Response('', { status, headers })
+
+describe('withRetry', () => {
+  it('passes through a 200 response on the first attempt', async () => {
+    const underlying = vi.fn(async () => ok(200))
+    const fetch = withRetry(underlying as any)
+    const r = await fetch('https://x' as any)
+    expect(r.status).toBe(200)
+    expect(underlying).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries transient statuses and returns the eventual success', async () => {
+    const underlying = vi.fn()
+      .mockResolvedValueOnce(ok(503))
+      .mockResolvedValueOnce(ok(200))
+    const fetch = withRetry(underlying as any, { baseBackoffMs: 1, maxBackoffMs: 1 })
+    const r = await fetch('https://x' as any)
+    expect(r.status).toBe(200)
+    expect(underlying).toHaveBeenCalledTimes(2)
+  })
+
+  it('honors Retry-After (seconds) as the wait floor', async () => {
+    const underlying = vi.fn()
+      .mockResolvedValueOnce(ok(429, { 'retry-after': '0' }))
+      .mockResolvedValueOnce(ok(200))
+    const fetch = withRetry(underlying as any, { baseBackoffMs: 1, maxBackoffMs: 1 })
+    const r = await fetch('https://x' as any)
+    expect(r.status).toBe(200)
+  })
+
+  it('stops retrying after maxAttempts and returns the last response', async () => {
+    const underlying = vi.fn(async () => ok(503))
+    const fetch = withRetry(underlying as any, { maxAttempts: 3, baseBackoffMs: 1, maxBackoffMs: 1 })
+    const r = await fetch('https://x' as any)
+    expect(r.status).toBe(503)
+    expect(underlying).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not retry non-transient statuses', async () => {
+    const underlying = vi.fn(async () => ok(401))
+    const fetch = withRetry(underlying as any, { baseBackoffMs: 1, maxBackoffMs: 1 })
+    const r = await fetch('https://x' as any)
+    expect(r.status).toBe(401)
+    expect(underlying).toHaveBeenCalledTimes(1)
+  })
+
+  it('aborts during the backoff sleep when the caller signal fires', async () => {
+    const underlying = vi.fn(async () => ok(503))
+    const fetch = withRetry(underlying as any, { baseBackoffMs: 1000, maxBackoffMs: 1000 })
+    const controller = new AbortController()
+    const p = fetch('https://x' as any, { signal: controller.signal } as any)
+    setTimeout(() => controller.abort(new Error('user abort')), 5)
+    await expect(p).rejects.toThrow('user abort')
+  })
+})

--- a/xmcl-runtime/user/utils/withRetry.ts
+++ b/xmcl-runtime/user/utils/withRetry.ts
@@ -1,0 +1,83 @@
+/**
+ * Compose a retrying `fetch` on top of any underlying `fetch` implementation.
+ *
+ * The launcher's `app.fetch` resolves to Electron's `net.fetch` (with an
+ * undici fallback on network errors). Neither path applies undici's
+ * `interceptors.retry`, so we wrap the fetch on the caller side to add
+ * retry semantics for transient HTTP statuses (408 / 425 / 429 / 5xx),
+ * honoring the `Retry-After` header. See issue #1445.
+ *
+ * Kept in the launcher (not in `@xmcl/user`) on purpose: the auth library
+ * stays a pure protocol implementation with a single fetch injection
+ * point, and the consumer decides on retry policy / dispatcher.
+ */
+export interface WithRetryOptions {
+  /** HTTP statuses to retry. Default: [408, 425, 429, 500, 502, 503, 504]. */
+  statusCodes?: number[]
+  /** Max attempts including the first. Default: 4. */
+  maxAttempts?: number
+  /** Cap for the exponential backoff (ms). Default: 30_000. */
+  maxBackoffMs?: number
+  /** Base delay for the exponential backoff (ms). Default: 500. */
+  baseBackoffMs?: number
+}
+
+const DEFAULT_STATUS_CODES = [408, 425, 429, 500, 502, 503, 504]
+
+/**
+ * Wrap a `fetch` so it retries transient failures.
+ *
+ * - Honors `Retry-After` (seconds or HTTP-date) for the wait duration,
+ *   never sleeping less than the exponential-backoff baseline.
+ * - Aborts cleanly when the caller-supplied `AbortSignal` fires during a
+ *   backoff sleep.
+ * - Re-reads the response body only on the final attempt -- intermediate
+ *   responses are discarded with `cancel()` to free the socket.
+ */
+export function withRetry(underlying: typeof fetch, options: WithRetryOptions = {}): typeof fetch {
+  const statusCodes = new Set(options.statusCodes ?? DEFAULT_STATUS_CODES)
+  const maxAttempts = options.maxAttempts ?? 4
+  const maxBackoffMs = options.maxBackoffMs ?? 30_000
+  const baseBackoffMs = options.baseBackoffMs ?? 500
+
+  return (async (input: any, init?: any) => {
+    const signal: AbortSignal | undefined = init?.signal
+    let lastResponse: Response | undefined
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const response = await underlying(input, init)
+      if (!statusCodes.has(response.status) || attempt === maxAttempts - 1) {
+        return response
+      }
+      lastResponse = response
+
+      // Compute wait: exponential backoff, overridden by Retry-After when larger.
+      let waitMs = Math.min(maxBackoffMs, baseBackoffMs * Math.pow(2, attempt))
+      const retryAfter = response.headers.get('retry-after')
+      if (retryAfter) {
+        const asInt = parseInt(retryAfter, 10)
+        if (!Number.isNaN(asInt)) {
+          waitMs = Math.max(waitMs, asInt * 1000)
+        } else {
+          const dateMs = Date.parse(retryAfter)
+          if (!Number.isNaN(dateMs)) {
+            waitMs = Math.max(waitMs, dateMs - Date.now())
+          }
+        }
+      }
+
+      // Free the socket before sleeping; we'll issue a fresh request.
+      try { await response.body?.cancel() } catch { /* ignore */ }
+
+      await new Promise<void>((resolve, reject) => {
+        const t = setTimeout(resolve, Math.max(0, waitMs))
+        const onAbort = () => {
+          clearTimeout(t)
+          reject(signal?.reason ?? new Error('Aborted'))
+        }
+        signal?.addEventListener('abort', onAbort, { once: true })
+      })
+    }
+    // Should be unreachable: the loop returns on its last iteration.
+    return lastResponse as Response
+  }) as typeof fetch
+}


### PR DESCRIPTION
Single-branch batch for the 5 P2 telemetry items surfaced by the 2026-05-16 triage pass, all confirmed still present in 0.56.1 / 0.56.2 before being filed. One commit per issue; each commit message contains the full rationale and links the issue.

| Commit | Issue | Problem (App Insights `problemId`) | 14-d baseline |
| --- | --- | --- | --- |
| `fix(curseforge): short-circuit empty-fingerprint API calls` | #1443 | `CurseforgeApiError at CurseforgeV1Client.getFingerprintsMatchesByGameId` | 2 131 ev / **610 users** |
| `fix(user): suppress ProfileNotFoundError from telemetry`     | #1442 | `ProfileNotFoundError at MojangClient.getProfile` | 2 903 ev / **551 users** |
| `fix(user): retry login_with_xbox on 408/429/5xx + map known XErr codes` | #1445 | `MicrosoftOLoginMicrosoftError at process.processTicksAndRejections` | 1 210 ev / **241 users** |
| `fix(protocol): swallow ERR_INVALID_STATE on aborted stream bridges` | #1446 | `TypeError at new NodeError` (`Invalid state: Controller is already closed`) | 564 ev / **131 users** |
| `fix(modrinth): handle null version_id deps without throwing` | #1444 | `TypeError at async visit` (`Missing X:null during resolve modrinth deps`) | 246 ev / **126 users** |

## What each commit does

### `fix(curseforge): short-circuit empty-fingerprint API calls` — #1443
Early-return the empty `FingerprintsMatchesResult['data']` shape from both `getFingerprintsMatchesByGameId` and its fuzzy variant when the input array is empty. CurseForge currently rejects those calls with `HTTP 400 "Fingerprints are required."` for ~610 users, burning quota for nothing.

### `fix(user): suppress ProfileNotFoundError from telemetry` — #1442
`MicrosoftAccountSystem.loginMicrosoft` was sending the raw `ProfileNotFoundError` through `logger.error()` before wrapping it in a `UserException`. The `UserException` is correctly filtered by `telemetry.ts`, but the raw error reached `trackException` first. Route it through `logger.warn()` instead (still visible locally, never reaches App Insights) and add `ProfileNotFoundError` to `ErrorDiagnose.processError()` as defense-in-depth.

### `fix(user): retry login_with_xbox on 408/429/5xx + map known XErr codes` — #1445
Two related changes:
- **Retry:** `MicrosoftAuthenticator.loginMinecraftWithXBox` now retries on `408 / 425 / 429 / 5xx` with capped exponential backoff (max 4 attempts, max 30 s, respects `Retry-After` as seconds or HTTP-date, abort-aware).
- **XErr classification:** known XErr codes from XSTS `/authorize` (`2148916233` no Xbox profile, `2148916235` region-locked, `2148916236/7` adult-verification, `2148916238` child account, `2148916227` banned) plus residual `408/429` are now `logger.warn`'d, not `logger.error`'d. They still throw the existing `UserException` for the UI; they just stop polluting telemetry.

### `fix(protocol): swallow ERR_INVALID_STATE on aborted stream bridges` — #1446
Every `Readable.fromWeb(...)` adaptor in the protocol bridges (`pluginCommonProtocol`, `ElectronSession`, `optifine`) now attaches an `error` listener that silently drops `ERR_INVALID_STATE` / `Controller is already closed` (the late-enqueue-after-abort race) and re-emits anything else via `destroy()`. Backstop suppression also lives in `ErrorDiagnose.processError()` since the minified async stack made the call sites unidentifiable from telemetry alone.

### `fix(modrinth): handle null version_id deps without throwing` — #1444
Modrinth allows `version_id: null` on a dependency to mean "any compatible version". When our loader+game-version filter returns zero versions for that project, the old visitor threw `TypeError("Missing X:null during resolve modrinth deps ...")` which propagated through SWRV and failed the entire dependency tree fetch. Now:
- Non-required deps: skip silently.
- Required deps: one `console.warn` with the full filter context, return `[]` for that subtree, let the rest of the tree resolve.

## Verification

`pnpm check` is clean across all four packages (`xmcl-runtime-api`, `xmcl-runtime`, `xmcl-electron-app`, `xmcl-keystone-ui`).

After the next release, this query in `xmcl-client-insight` should show all five `problemId`s ≪ baseline:

```kusto
exceptions
| where application_Version startswith "0.57" or application_Version startswith "0.56.3"
| where problemId in (
    "CurseforgeApiError at CurseforgeV1Client.getFingerprintsMatchesByGameId",
    "ProfileNotFoundError at MojangClient.getProfile",
    "MicrosoftOLoginMicrosoftError at process.processTicksAndRejections",
    "TypeError at new NodeError",
    "TypeError at async visit"
  )
| summarize cnt=count(), users=dcount(user_Id) by problemId
| order by users desc
```

Closes #1442
Closes #1443
Closes #1444
Closes #1445
Closes #1446
