### PR TITLE
fix(telemetry): batch 0.56.4 fixes (SQLite corruption recovery + 10 expected-state suppressions + 3 renderer bugs)

### DIFF
--- a/packages/file-transfer/error.ts
+++ b/packages/file-transfer/error.ts
@@ -1,14 +1,28 @@
 
+function safeSet(err: Error, key: string, value: unknown): void {
+  try {
+    (err as any)[key] = value
+  } catch {
+    try {
+      Object.defineProperty(err, key, { value, configurable: true, writable: true, enumerable: false })
+    } catch {
+      // The target property is non-writable, non-configurable and the
+      // object is frozen. Accept it — better to surface the original
+      // error than to crash the error pipeline with a `TypeError:
+      // Cannot set property name of <obj> which has only a getter`
+      // (problemId "TypeError at decorateError" in telemetry).
+    }
+  }
+}
+
 export function decorateError(
   err: Error,
   urls: string[],
   headers: Record<string, any>,
   destination: string,
 ) {
-  Object.assign(err, {
-    name: 'DownloadError',
-    urls: urls.join(' '),
-    headers,
-    destination,
-  })
+  safeSet(err, 'name', 'DownloadError')
+  safeSet(err, 'urls', urls.join(' '))
+  safeSet(err, 'headers', headers)
+  safeSet(err, 'destination', destination)
 }

--- a/packages/resource/core/getOrParseMetadata.ts
+++ b/packages/resource/core/getOrParseMetadata.ts
@@ -42,6 +42,18 @@ export async function getOrParseMetadata(
       err.name === 'FileNotFoundError' ||
       err.name === 'PermissionError'
     ) {
+      // Persist the failure on the snapshot so a future revalidate
+      // (e.g. renderer reconnect) can skip this file as long as its
+      // mtime/ino haven't changed, instead of re-running the parser and
+      // re-emitting the same error every time. See issue #1453.
+      if (parse && record.parseError !== err.name) {
+        context.db
+          .updateTable('snapshots')
+          .set({ parseError: err.name })
+          .where('domainedPath', '=', record.domainedPath)
+          .execute()
+          .catch((e) => context.onError(e))
+      }
       context.throwException({ type: 'parseResourceException', code: err.name, path: file.path })
     }
     throw err

--- a/packages/resource/core/migrate.ts
+++ b/packages/resource/core/migrate.ts
@@ -9,6 +9,7 @@ export class ResourceMigrateProvider implements MigrationProvider {
       2: v2,
       2.1: v21,
       2.2: v22,
+      2.3: v23,
     })
   }
 }
@@ -17,6 +18,12 @@ async function fixSnapshotTable(db: Kysely<Database>) {
   let columns = await sql`PRAGMA table_info(snapshots)`.execute(db)
   if (columns.rows.some((c: any) => c.name === 'ctime')) {
     await v21.up(db)
+  }
+  // Ensure the parseError column exists — older DBs that completed the
+  // initial migration before v2.3 was introduced may be missing it. Run
+  // v23.up defensively (it is a no-op when the column is already present).
+  if (!columns.rows.some((c: any) => c.name === 'parseError')) {
+    await v23.up(db)
   }
   columns = await sql`PRAGMA table_info(snapshots)`.execute(db)
   if (columns.rows.some((c: any) => c.name === 'ctime')) {
@@ -28,9 +35,10 @@ async function fixSnapshotTable(db: Kysely<Database>) {
       .addColumn('mtime', 'integer', (col) => col.notNull())
       .addColumn('fileType', 'varchar', (col) => col.notNull())
       .addColumn('sha1', 'char(40)', (col) => col.notNull())
+      .addColumn('parseError', 'varchar')
       .execute()
     // copy data
-    await sql`insert into snapshots_temp select domainedPath, ino, mtime, fileType, sha1 from snapshots`.execute(
+    await sql`insert into snapshots_temp select domainedPath, ino, mtime, fileType, sha1, parseError from snapshots`.execute(
       db,
     )
     // drop old table
@@ -176,5 +184,19 @@ const v22: Migration = {
       return
     }
     await db.schema.alterTable('resources').addColumn(ResourceType.Neoforge, 'json').execute()
+  },
+}
+
+// Add nullable `parseError` column on snapshots so the resource manager
+// can remember which files were already scanned and known to be
+// unparseable. Used to suppress repeated parse errors when the renderer
+// reconnects and triggers revalidate(). See issue #1453.
+const v23: Migration = {
+  async up(db: Kysely<Database>): Promise<void> {
+    const columns = await sql`PRAGMA table_info(snapshots)`.execute(db)
+    if (columns.rows.some((c: any) => c.name === 'parseError')) {
+      return
+    }
+    await db.schema.alterTable('snapshots').addColumn('parseError', 'varchar').execute()
   },
 }

--- a/packages/resource/core/takeSnapshot.ts
+++ b/packages/resource/core/takeSnapshot.ts
@@ -25,6 +25,11 @@ export async function takeSnapshot(
     mtime: file.mtime,
     fileType: type,
     sha1,
+    // A fresh snapshot represents the current bytes of the file — any
+    // previously recorded parse error is no longer authoritative. The
+    // worker queue will re-attempt parsing and (re-)set `parseError` if
+    // the file still does not parse.
+    parseError: null as string | null,
   }
 
   if (parse) {
@@ -46,6 +51,7 @@ export async function takeSnapshot(
                 ino: r.ino,
                 fileType: type,
                 sha1,
+                parseError: null,
               })),
             )
             .onConflict((oc) => {
@@ -53,6 +59,7 @@ export async function takeSnapshot(
                 mtime: eb.ref('mtime'),
                 fileType: eb.ref('fileType'),
                 sha1: eb.ref('sha1'),
+                parseError: eb.ref('parseError'),
               }))
             })
         },
@@ -71,6 +78,7 @@ export async function takeSnapshot(
           mtime: record!.mtime,
           fileType: record!.fileType,
           sha1: record!.sha1,
+          parseError: null,
         })
       })
       .execute()

--- a/packages/resource/core/watchResourcesDirectory.ts
+++ b/packages/resource/core/watchResourcesDirectory.ts
@@ -23,6 +23,7 @@ function createRevalidateFunction(
   onResourceQueue: (job: ResourceWorkerQueuePayload) => void,
   onResourceTouched: ResouceEmitFunc,
   onResourcePostRevalidate: (files: File[]) => void,
+  onResourceKnownBroken: (filePath: string, code: string) => void,
 ) {
   async function getFilesStatus() {
     const entries = await getFiles(dir, domain).catch((e) => {
@@ -78,6 +79,15 @@ function createRevalidateFunction(
       .map((jobs) => {
         if (!jobs[1]) {
           onResourceQueue({ filePath: jobs[0].path, file: jobs[0] })
+          return undefined
+        }
+        // The file is already known to be unparseable and its on-disk
+        // bytes haven't changed (mtime+ino still match the snapshot).
+        // Re-running the parser would just re-throw the same exception
+        // and re-toast the user — surface the cached error instead and
+        // drop the file from the worker queue. See issue #1453.
+        if (jobs[1].parseError) {
+          onResourceKnownBroken(jobs[0].path, jobs[1].parseError)
           return undefined
         }
         return jobs
@@ -314,6 +324,19 @@ export function watchResourcesDirectory({
     workerQueue.push(job)
   }
 
+  // Surface a previously recorded parse error for a file whose bytes
+  // have not changed since the worker last failed on it. Deduped
+  // against `state.errors` so the renderer's toast notifier (which
+  // fires on every `Upsert`) only blares once per broken file per
+  // session, instead of every revalidate / focus / reconnect.
+  // See issue #1453.
+  const onResourceKnownBroken = (filePath: string, code: string) => {
+    if (disposed) return
+    const existing = state.errors.find((e) => e.path === filePath)
+    if (existing && existing.code === code) return
+    errorUpdate.push([{ path: filePath, code }, ResourceErrorAction.Upsert])
+  }
+
   const onResourcePostRevalidate = (files: File[]) => {
     const all = Object.fromEntries(files.map((f) => [f.path, f]))
     for (const file of state.files) {
@@ -337,6 +360,7 @@ export function watchResourcesDirectory({
       onResourceEmit(f, r, m)
     },
     onResourcePostRevalidate,
+    onResourceKnownBroken,
   )
 
   const watcher = createWatcher(
@@ -378,7 +402,10 @@ export function watchResourcesDirectory({
     // telemetry.
     const ex = (e as any)?.exception
     if (ex && ex.type === 'parseResourceException' && typeof ex.code === 'string') {
-      errorUpdate.push([{ path: filePath, code: ex.code }, ResourceErrorAction.Upsert])
+      // Reuse the deduped path so the renderer doesn't get a fresh
+      // Upsert (and toast) for a file that's already marked broken with
+      // the same code. See issue #1453.
+      onResourceKnownBroken(filePath, ex.code)
     }
     context.onError(e)
   }

--- a/packages/resource/schema.ts
+++ b/packages/resource/schema.ts
@@ -43,6 +43,16 @@ export interface ResourceSnapshotTable {
    * The mtime of the file
    */
   mtime: number
+  /**
+   * The last parser error code for this snapshot, if any. Set when the
+   * resource worker fails to parse this file with a known broken-file
+   * signature (e.g. `InvalidZipFileError`). When present, revalidate
+   * skips re-parsing this snapshot — the file is treated as "scanned
+   * and known broken" until its mtime/ino changes (i.e. the user fixes
+   * or replaces it). This avoids spamming the UI with the same parse
+   * error every time the renderer reconnects. See issue #1453.
+   */
+  parseError?: string | null
 }
 
 export interface Database {

--- a/packages/sqlite/SqliteWASMDriver.ts
+++ b/packages/sqlite/SqliteWASMDriver.ts
@@ -5,7 +5,17 @@ import {
   SqliteWASMDialectDatabaseConfig,
   SqliteWASMDialectWorkerConfig,
 } from './SqliteWASMDialectConfig'
-import { existsSync, rmSync } from 'fs'
+import { existsSync, renameSync, rmSync } from 'fs'
+
+// Messages that indicate the on-disk database file is unrecoverable and
+// will keep producing the same SQLite3Error for every subsequent query.
+// Reopening the same file does not help: we must move the file aside so
+// `database()` creates a fresh one. See issue #1429.
+const CORRUPT_MESSAGES = [
+  'database disk image is malformed',
+  'file is not a database',
+  'file is encrypted or is not a database',
+]
 
 declare module 'node-sqlite3-wasm' {
   interface Statement {
@@ -110,6 +120,46 @@ export class SqliteWASMDriver extends AbstractSqliteDriver {
             if (e instanceof SQLite3Error) {
               e.isDisposed = true
             }
+          } else if (CORRUPT_MESSAGES.includes(e.message)) {
+            // The file itself is corrupt. Reopening the same file would
+            // just produce the same error on every query — flood that
+            // turned the original "Database already closed" fix from
+            // #1429 into the 0.56.4 "disk image is malformed" storm
+            // (~1860 events/user). Move the bad file aside, open a
+            // fresh one, and let the higher-level retry loop in
+            // `pluginResourceWorker` re-run migrations on next launch.
+            try {
+              this.#db?.close()
+            } catch {}
+            try {
+              if (this.#config.databasePath && existsSync(this.#config.databasePath)) {
+                const bk = `${this.#config.databasePath}.corrupt.${Date.now()}.bk`
+                renameSync(this.#config.databasePath, bk)
+              }
+            } catch {}
+            try {
+              this.#db = this.#config.database()
+            } catch {
+              // Best-effort: if we can't even open a fresh handle,
+              // leave the existing one in place. Subsequent errors
+              // will still be flagged isDisposed below.
+            }
+            if (e instanceof SQLite3Error) {
+              e.isDisposed = true
+            }
+            // Surface to the consumer exactly once so it can mark the
+            // database as not-ready / show a "please restart" hint.
+            this.#config.onError?.(e)
+          } else if (e.message.startsWith('no such table')) {
+            // Schema isn't present — either the migration never ran on
+            // this file or it ran on a sibling that's since been
+            // swapped out. Don't retry: just flag the error so the
+            // telemetry sink suppresses the per-query repeat, and let
+            // the consumer notice via `databaseReadySet(false)`.
+            if (e instanceof SQLite3Error) {
+              e.isDisposed = true
+            }
+            this.#config.onError?.(e)
           } else {
             this.#config.onError?.(e)
           }

--- a/xmcl-keystone-ui/src/components/StoreExploreCardModern.vue
+++ b/xmcl-keystone-ui/src/components/StoreExploreCardModern.vue
@@ -5,7 +5,7 @@
     class="explore-card group relative bg-surface rounded-2xl overflow-hidden flex flex-col h-full cursor-pointer"
     role="button"
     tabindex="0"
-    :aria-label="value?.title || value?.name || ''"
+    :aria-label="value?.title || ''"
     @click="$emit('click')"
     @keydown.enter.prevent="$emit('click')"
     @keydown.space.prevent="$emit('click')"

--- a/xmcl-keystone-ui/src/telemetry.ts
+++ b/xmcl-keystone-ui/src/telemetry.ts
@@ -34,6 +34,23 @@ appInsights.addTelemetryInitializer((envelope) => {
       if (exception.message.includes('Failed to fetch')) {
         return false
       }
+      // Renderer-side fetch / SWR cancellations propagate when the user
+      // navigates away while a Modrinth/Curse list is loading. Same
+      // class as the runtime-side AbortError suppression in
+      // ErrorDiagnose (issue #1453 batch).
+      if (exception.message === 'The operation was aborted' ||
+          exception.message === 'This operation was aborted' ||
+          exception.message.startsWith('AbortError')) {
+        return false
+      }
+      // `getSWRV` throws this when a caller passes a model whose key
+      // ref resolved to undefined (e.g. modpack panel mounted before
+      // its instance ref is ready). The promise rejection already
+      // re-renders the panel with the empty state -- no need to ship
+      // a per-mount exception. 23 ev/11 users in 0.56.4.
+      if (exception.message === 'Key is required') {
+        return false
+      }
       if (exception.message.includes('SyntaxError: {"code":24}')) {
         const baseData: any = envelope.baseData = envelope.baseData ?? {}
         const properties = baseData.properties = baseData.properties ?? {}

--- a/xmcl-keystone-ui/src/telemetry.ts
+++ b/xmcl-keystone-ui/src/telemetry.ts
@@ -51,7 +51,26 @@ appInsights.addTelemetryInitializer((envelope) => {
       if (exception.message === 'Key is required') {
         return false
       }
-      if (exception.message.includes('SyntaxError: {"code":24}')) {
+      // Vuetify VChip `isFixedPosition` reads `getComputedStyle` on a
+      // ref that can become null between mount and the next tick. The
+      // resolved stack lives entirely in `VChip-*.js` (no app code), so
+      // there is no patch we can apply -- only suppress here until the
+      // upstream Vuetify fix lands. Issue #1426 (1 490 ev / 747 users
+      // in 7d on 0.56.4, with zero functional impact).
+      if (exception.message ===
+          "Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.") {
+        return false
+      }
+      // vue-i18n message-compiler error. Production messages come back
+      // as plain `SyntaxError: 24` (no JSON wrapper), so the previous
+      // match string `SyntaxError: {"code":24}` never fired and the
+      // locale/route customDimensions added in 0.56.4 (#1427) came back
+      // empty for all 4 992 ev / 380 users on 0.56.4. Match the raw
+      // shape and attach the dimensions we actually have. We also try
+      // to grab the source snippet vue-i18n stashes on the error so the
+      // next pass can locate the broken translation without leaking
+      // user data.
+      if (/^SyntaxError:\s*(?:\{\s*"code"\s*:\s*)?24\b/.test(exception.message)) {
         const baseData: any = envelope.baseData = envelope.baseData ?? {}
         const properties = baseData.properties = baseData.properties ?? {}
         try {
@@ -63,6 +82,22 @@ appInsights.addTelemetryInitializer((envelope) => {
           // it lets us narrow the broken translation key to a single
           // screen in the next release.
           properties.route = typeof window !== 'undefined' ? window.location.hash : ''
+        } catch {}
+        try {
+          const original: any = exception as any
+          // vue-i18n attaches the offending source string to the error
+          // (CompileErrorCodes 24 = unterminated string literal). Take
+          // the first 80 chars only -- enough to identify the broken
+          // ICU placeholder, short enough to stay below
+          // customDimensions' 8 KB cap and to avoid spilling user
+          // input from format-arguments.
+          const src = original.location?.source ?? original.source ?? original.codeFrame
+          if (typeof src === 'string') {
+            properties.snippet = src.slice(0, 80)
+          }
+          if (typeof original.code === 'number' || typeof original.code === 'string') {
+            properties.compileCode = String(original.code)
+          }
         } catch {}
         // Keep the legacy field for back-compat in case anything else
         // reads it off `envelope.data`.

--- a/xmcl-keystone-ui/src/util/mod.ts
+++ b/xmcl-keystone-ui/src/util/mod.ts
@@ -326,7 +326,17 @@ export function getModFileFromResource(resource: Resource, runtime: RuntimeVersi
     modItem.version = meta.version
     modItem.name = meta.name ?? meta.id
     modItem.description = meta.description ?? ''
-    modItem.authors = meta.authors?.map(a => typeof a === 'string' ? a : a.name) ?? []
+    // Fabric mods in the wild sometimes serialise `authors` as a single
+    // string instead of the spec-mandated array, which crashed the UI
+    // with `TypeError: se.authors?.map is not a function` (telemetry,
+    // 0.56.4). Normalise both shapes before mapping.
+    const fabricAuthorsRaw: any = meta.authors
+    const fabricAuthors: any[] = Array.isArray(fabricAuthorsRaw)
+      ? fabricAuthorsRaw
+      : typeof fabricAuthorsRaw === 'string'
+        ? [fabricAuthorsRaw]
+        : []
+    modItem.authors = fabricAuthors.map(a => typeof a === 'string' ? a : a.name)
     modItem.links = getFabricLikeModLinks(meta.contact)
     modItem.license = typeof meta.license === 'string' ? { name: meta.license } : meta.license ? { name: meta.license?.[0] } : undefined
   }

--- a/xmcl-runtime/infra/errors/ErrorDiagnose.ts
+++ b/xmcl-runtime/infra/errors/ErrorDiagnose.ts
@@ -109,6 +109,61 @@ export class ErrorDiagnose {
     if (e.name === 'MicrosoftOAuthSlientFailed') {
       return true
     }
+    // Network/HTTP fetch was aborted by the caller (component unmount,
+    // user navigation, app shutdown). Surfaces both as
+    // `AbortError at Timeout.cancelListenerHandler` (27/19 in 0.56.4)
+    // and indirectly as `Error at TelemetryClient2.trackException
+    // AbortError` when the AI sender's HTTP request itself is aborted
+    // during shutdown (24/20). Always expected.
+    if (e.name === 'AbortError' || e.message === 'The operation was aborted' || e.message === 'This operation was aborted') {
+      return true
+    }
+    // Modpack install lock file (.install-profile) was deleted or the
+    // installer never wrote one (e.g. user wiped the instance dir
+    // mid-install). The user-facing flow already shows a "no pending
+    // install" notice; suppress the per-file ENOENT spam (91 ev/12
+    // users in 0.56.4).
+    if ((e as any).name === 'InstallInstanceFilesError' && isSystemError(e) && e.code === 'ENOENT' && /\.install-profile/.test(e.message)) {
+      return true
+    }
+    // Version JSON is missing -- user deleted versions/<v>/<v>.json
+    // or never finished installing the version. Already handled by
+    // the launcher UI (offers re-install); suppress telemetry storm.
+    if (e.name === 'MissingVersionJson') {
+      return true
+    }
+    // `linkOrCopyFile` -> ENOENT when the destination's mods folder
+    // hasn't been created yet (e.g. instance points at a freshly
+    // cleaned directory). The installer's outer flow already retries
+    // with a `mkdir -p`; telemetry storm (21/5) is just noise.
+    if (e.name === 'OptifineInstallError' && /ENOENT/.test(e.message)) {
+      return true
+    }
+    // `rm -rf <instance>` failed because the user has a file open in
+    // the directory (Explorer window, antivirus scan, running game).
+    // 21/14 in 0.56.4 -- not a defect, user action required.
+    if (e.name === 'InstanceDeleteError' && isSystemError(e) && (e.code === 'EBUSY' || e.code === 'ENOTEMPTY')) {
+      return true
+    }
+    // Microsoft OAuth standard error responses that mean "user closed
+    // / denied / the auth server is having a moment". Follow-up to
+    // #1445: the existing isExpectedAuthFailure / isKnownXErr cover
+    // the XBox numeric XErr codes but not the OAuth-layer codes that
+    // come back from MSAL itself.
+    if (e.name === 'MicrosoftOLoginMicrosoftError' && typeof e.message === 'string' &&
+        /\b(access_denied|server_error|invalid_request|consent_required|interaction_required|login_required|user_cancelled)\b/.test(e.message)) {
+      return true
+    }
+    // node-sqlite3-wasm surfaces native open failures as plain `Error`
+    // with messages like `Failed to open: Access is denied. (0x5)`
+    // (147/33 users in 0.56.4). They're the same OS-level class as
+    // SQLite3Error "unable to open database file" but lose the
+    // `SQLite3Error` constructor across the WASM boundary, so the
+    // existing guard above doesn't catch them. Permission denied on
+    // the data dir is user/AV state, not a defect.
+    if (typeof e.message === 'string' && /^Failed to open:.*\(0x[0-9A-Fa-f]+\)/.test(e.message)) {
+      return true
+    }
     return false
   }
 }

--- a/xmcl-runtime/infra/errors/ErrorDiagnose.ts
+++ b/xmcl-runtime/infra/errors/ErrorDiagnose.ts
@@ -134,8 +134,9 @@ export class ErrorDiagnose {
     }
     // `linkOrCopyFile` -> ENOENT when the destination's mods folder
     // hasn't been created yet (e.g. instance points at a freshly
-    // cleaned directory). The installer's outer flow already retries
-    // with a `mkdir -p`; telemetry storm (21/5) is just noise.
+    // cleaned directory). InstallService now ensures the folder
+    // before copying, but keep this guard as a last line of defense
+    // in case any other caller forgets. 21 ev / 5 users in 0.56.4.
     if (e.name === 'OptifineInstallError' && /ENOENT/.test(e.message)) {
       return true
     }

--- a/xmcl-runtime/install/InstallService.ts
+++ b/xmcl-runtime/install/InstallService.ts
@@ -970,7 +970,13 @@ export class InstallService extends AbstractService implements IInstallService {
         }),
       })
     }
-    await linkOrCopyFile(path, join(options.instancePath, 'mods', `OptiFine-${version}.jar`)).catch(
+    const modsDir = join(options.instancePath, 'mods')
+    // Make sure the destination directory exists -- a freshly created
+    // or wiped instance has no `mods/` yet, which previously surfaced
+    // as `OptifineInstallError: Failed to copy OptiFine to mods folder.
+    // ENOENT` (21 ev / 5 users in 0.56.4 telemetry).
+    await ensureDir(modsDir)
+    await linkOrCopyFile(path, join(modsDir, `OptiFine-${version}.jar`)).catch(
       (e) => {
         throw new AnyError(
           'OptifineInstallError',

--- a/xmcl-runtime/instance/InstanceService.ts
+++ b/xmcl-runtime/instance/InstanceService.ts
@@ -41,7 +41,12 @@ const INSTANCES_FOLDER = 'instances'
  */
 @ExposeServiceKey(InstanceServiceKey)
 export class InstanceService extends StatefulService<InstanceState> implements IInstanceService {
-  #removeHandlers: Record<string, WeakRef<() => Promise<void> | void>[]> = {}
+  // Strong references so the handler stays alive until removal or
+  // explicit unregister; previously these were `WeakRef`s, which made
+  // inline arrow handlers (e.g. abort-on-delete callbacks registered
+  // by InstanceInstallService) eligible for GC mid-install and break
+  // the install/delete cancellation handshake.
+  #removeHandlers: Record<string, Array<() => Promise<void> | void>> = {}
   #onRenamedInstancePath?: (oldPath: string, newPath: string) => void
 
   constructor(
@@ -215,11 +220,16 @@ export class InstanceService extends StatefulService<InstanceState> implements I
     }
   }
 
-  registerRemoveHandler(path: string, handler: () => Promise<void> | void) {
+  registerRemoveHandler(path: string, handler: () => Promise<void> | void): () => void {
     if (!this.#removeHandlers[path]) {
       this.#removeHandlers[path] = []
     }
-    this.#removeHandlers[path].push(new WeakRef(handler))
+    const list = this.#removeHandlers[path]
+    list.push(handler)
+    return () => {
+      const idx = list.indexOf(handler)
+      if (idx >= 0) list.splice(idx, 1)
+    }
   }
 
   @Singleton((v) => v)
@@ -380,32 +390,57 @@ export class InstanceService extends StatefulService<InstanceState> implements I
     const instanceLock = this.mutex.of(LockKey.instance(path))
     if (isManaged && (await exists(path))) {
       await lock.runExclusive(async () => {
+        // Reject any install requests currently waiting for the instance
+        // lock so they don't start work that we are about to wipe out.
+        // NOTE: `cancel()` only rejects pending acquires; it does NOT
+        // abort the active holder. The active holder is signalled via
+        // the remove handlers below, and our own `runExclusive` call
+        // (queued synchronously before any `await`) will resolve only
+        // after that holder releases.
         instanceLock.cancel()
-        const oldHandlers = this.#removeHandlers[path]
-        for (const handlerRef of oldHandlers || []) {
-          handlerRef.deref()?.()
-        }
-        if (deleteData) {
-          try {
-            await rm(path, { recursive: true, force: true, maxRetries: 1 })
-          } catch (e) {
-            if (isSystemError(e) && (e.code === ENOENT_ERROR || e.code === 'EPERM')) {
-              this.warn(`Fail to remove instance ${path}`)
-            } else {
-              if ((e as any).name === 'Error') {
-                ;(e as any).name = 'InstanceDeleteError'
-              }
-              throw e
-            }
-          }
-        } else {
-          // Rename to hidden
-          const name = basename(path)
-          const newPath = join(dirname(path), '.' + name)
-          await rename(path, newPath).catch(() => undefined)
-        }
 
-        this.#removeHandlers[path] = []
+        // Snapshot handlers and start them BEFORE awaiting, so they get
+        // a chance to flip an AbortSignal on the currently-running
+        // install. We do not await them out of band here — we await
+        // them inside `runExclusive` so a new caller cannot squeeze
+        // into the lock between handlers finishing and rm starting.
+        const oldHandlers = this.#removeHandlers[path] || []
+        const handlerPromises = oldHandlers.map((fn) => {
+          try {
+            return Promise.resolve(fn())
+          } catch (e) {
+            return Promise.reject(e)
+          }
+        })
+
+        await instanceLock.runExclusive(async () => {
+          // Wait for in-flight cleanup (e.g. install unwinding after
+          // abort) to complete. allSettled so a buggy handler can't
+          // block deletion.
+          await Promise.allSettled(handlerPromises)
+
+          if (deleteData) {
+            try {
+              await rm(path, { recursive: true, force: true, maxRetries: 1 })
+            } catch (e) {
+              if (isSystemError(e) && (e.code === ENOENT_ERROR || e.code === 'EPERM')) {
+                this.warn(`Fail to remove instance ${path}`)
+              } else {
+                if ((e as any).name === 'Error') {
+                  ;(e as any).name = 'InstanceDeleteError'
+                }
+                throw e
+              }
+            }
+          } else {
+            // Rename to hidden
+            const name = basename(path)
+            const newPath = join(dirname(path), '.' + name)
+            await rename(path, newPath).catch(() => undefined)
+          }
+
+          this.#removeHandlers[path] = []
+        })
       })
     }
 

--- a/xmcl-runtime/instance/deleteInstance.race.test.ts
+++ b/xmcl-runtime/instance/deleteInstance.race.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect } from 'vitest'
+import { Mutex } from 'async-mutex'
+
+/**
+ * Regression coverage for the InstallInstanceFilesError race fix.
+ *
+ * Bug: `InstanceService.deleteInstance` used to take a different mutex
+ * key (`LockKey.instanceRemove(p)`) from `InstanceInstallService.#install`
+ * (`LockKey.instance(p)`), and only called `instanceLock.cancel()` on
+ * the install lock. `async-mutex.cancel()` rejects PENDING acquires
+ * with E_CANCELED but does NOT abort the active holder, so `rm -rf`
+ * could run under an in-flight install. The install would then crash
+ * with `ENOENT open '.install-profile'` / `rename ENOENT|EPERM|EBUSY`
+ * on subsequent file ops.
+ *
+ * Fix: `deleteInstance` now (a) registers strong-ref remove handlers
+ * that the install uses to abort fast, (b) calls `instanceLock.cancel()`
+ * synchronously then `instanceLock.runExclusive(...)` BEFORE any await,
+ * so the delete is queued ahead of any new acquirer and only runs
+ * after the active holder releases.
+ *
+ * These tests verify the precise mutex handshake the production code
+ * depends on, without needing the full service DI graph.
+ */
+describe('deleteInstance / #install lock handshake', () => {
+  /** Mimic InstanceService.registerRemoveHandler / deleteInstance with
+   *  the new strong-ref + queue-before-await pattern. */
+  type RemoveHandler = () => Promise<void> | void
+  const makeRemoveRegistry = () => {
+    const handlers: RemoveHandler[] = []
+    return {
+      register: (h: RemoveHandler) => {
+        handlers.push(h)
+        return () => {
+          const i = handlers.indexOf(h)
+          if (i >= 0) handlers.splice(i, 1)
+        }
+      },
+      snapshot: () => handlers.slice(),
+    }
+  }
+
+  it('delete waits for an active install to release before rm', async () => {
+    const lock = new Mutex()
+    const events: string[] = []
+
+    // Simulated install holds the lock for some time, no abort.
+    const installDone = lock.runExclusive(async () => {
+      events.push('install:start')
+      await new Promise((r) => setTimeout(r, 30))
+      events.push('install:end')
+    })
+
+    // Yield so install has the lock.
+    await new Promise((r) => setTimeout(r, 5))
+
+    // Simulated deleteInstance: cancel pending, queue runExclusive
+    // SYNCHRONOUSLY (no await before it), then await.
+    lock.cancel()
+    const deleteDone = lock.runExclusive(async () => {
+      events.push('delete:rm')
+    })
+
+    await Promise.all([installDone, deleteDone])
+    expect(events).toEqual(['install:start', 'install:end', 'delete:rm'])
+  })
+
+  it('delete aborts an active install via remove handler and waits for graceful release', async () => {
+    const lock = new Mutex()
+    const registry = makeRemoveRegistry()
+    const events: string[] = []
+
+    // Simulated install: registers an abort handler, holds the lock,
+    // unwinds when aborted, throws AbortError, unregisters in finally.
+    const installAbort = new AbortController()
+    const installDone = (async () => {
+      const unregister = registry.register(() => installAbort.abort())
+      try {
+        await lock.runExclusive(async () => {
+          events.push('install:locked')
+          // Simulate long-running install loop that polls the signal.
+          for (let i = 0; i < 50; i++) {
+            installAbort.signal.throwIfAborted()
+            await new Promise((r) => setTimeout(r, 5))
+          }
+          events.push('install:completed')
+        })
+      } finally {
+        unregister()
+      }
+    })().catch((e) => {
+      events.push(`install:threw:${(e as Error).name}`)
+    })
+
+    await new Promise((r) => setTimeout(r, 10))
+
+    // deleteInstance simulation: invoke handlers (fast abort), then
+    // queue runExclusive synchronously.
+    lock.cancel()
+    const handlerPromises = registry.snapshot().map((fn) => {
+      try { return Promise.resolve(fn()) } catch (e) { return Promise.reject(e) }
+    })
+    const deleteDone = lock.runExclusive(async () => {
+      await Promise.allSettled(handlerPromises)
+      events.push('delete:rm')
+    })
+
+    await Promise.all([installDone, deleteDone])
+
+    expect(events).toContain('install:locked')
+    expect(events).toContain('install:threw:AbortError')
+    expect(events).not.toContain('install:completed')
+    expect(events.indexOf('delete:rm')).toBeGreaterThan(events.indexOf('install:threw:AbortError'))
+  })
+
+  it('delete cancels a pending install that has not yet acquired the lock', async () => {
+    const lock = new Mutex()
+    const events: string[] = []
+
+    // First install grabs the lock and holds it briefly.
+    const installA = lock.runExclusive(async () => {
+      events.push('A:locked')
+      await new Promise((r) => setTimeout(r, 20))
+    })
+
+    await new Promise((r) => setTimeout(r, 5))
+
+    // Second install QUEUES on the same lock — pending.
+    const installB = lock.runExclusive(async () => {
+      events.push('B:locked')
+    }).catch((e: Error) => {
+      // async-mutex throws `Error('request for lock canceled')`.
+      events.push(`B:cancelled:${e.message}`)
+    })
+
+    await new Promise((r) => setTimeout(r, 5))
+
+    // deleteInstance: cancel rejects pending B; then synchronously
+    // queue our own acquire (which is allowed because cancel() only
+    // affects acquires that were pending AT THE TIME of cancel).
+    lock.cancel()
+    const deleteDone = lock.runExclusive(async () => {
+      events.push('delete:rm')
+    })
+
+    await Promise.all([installA, installB, deleteDone])
+
+    expect(events).toContain('A:locked')
+    expect(events).toContain('B:cancelled:request for lock canceled')
+    expect(events).not.toContain('B:locked')
+    expect(events).toContain('delete:rm')
+  })
+
+  it('a buggy remove handler does not block deletion (allSettled semantics)', async () => {
+    const lock = new Mutex()
+    const registry = makeRemoveRegistry()
+    const events: string[] = []
+
+    // Register a handler that throws synchronously and another that
+    // rejects asynchronously — neither should prevent the rm step.
+    registry.register(() => { throw new Error('handler bug') })
+    registry.register(async () => { throw new Error('async handler bug') })
+
+    lock.cancel()
+    const handlerPromises = registry.snapshot().map((fn) => {
+      try { return Promise.resolve(fn()) } catch (e) { return Promise.reject(e) }
+    })
+    await lock.runExclusive(async () => {
+      await Promise.allSettled(handlerPromises)
+      events.push('delete:rm')
+    })
+
+    expect(events).toEqual(['delete:rm'])
+  })
+})
+
+/**
+ * Regression coverage for the secondary bug in
+ * `InstanceInstallService.#install`'s catch:
+ *
+ *   try { await prepareInstallFiles(...) }
+ *   catch (e) { await writeJson(currentStatePath, ...); throw e }
+ *
+ * If the inner `writeJson` itself threw (e.g. because a concurrent
+ * deleteInstance had just rm'd the dir, or AV held the file), the
+ * inner throw replaced the original error. Production telemetry only
+ * ever saw the generic ENOENT-on-`.install-profile` wrapper, never
+ * the true cause (download / zip / network). Fix: the inner writeJson
+ * is now `.catch`'d so it can never shadow `e`.
+ */
+describe('install catch must preserve original error', () => {
+  /**
+   * Replicates the exact shape of the production catch block. Kept
+   * intentionally small so it stays in sync with the real handler.
+   */
+  async function installCatchHelper(args: {
+    prepare: () => Promise<void>
+    writePartial: () => Promise<void>
+  }): Promise<void> {
+    try {
+      await args.prepare()
+    } catch (e) {
+      // Guarded — must not let writePartial's error shadow `e`.
+      await args.writePartial().catch(() => { /* swallowed */ })
+      throw e
+    }
+  }
+
+  it('preserves the prepareInstallFiles error when writeJson also fails', async () => {
+    const original = Object.assign(new Error('download failed: sha1 mismatch'), {
+      name: 'ChecksumNotMatchError',
+    })
+
+    let caught: any
+    try {
+      await installCatchHelper({
+        prepare: async () => { throw original },
+        writePartial: async () => {
+          const ioErr: any = new Error("ENOENT: no such file or directory, open '.install-profile'")
+          ioErr.code = 'ENOENT'
+          throw ioErr
+        },
+      })
+    } catch (e) {
+      caught = e
+    }
+
+    expect(caught).toBe(original)
+    expect(caught.name).toBe('ChecksumNotMatchError')
+  })
+
+  it('still propagates the prepareInstallFiles error when writeJson succeeds', async () => {
+    const original = new Error('zip stream closed')
+    original.name = 'ZipFileClosed'
+
+    let caught: any
+    try {
+      await installCatchHelper({
+        prepare: async () => { throw original },
+        writePartial: async () => { /* ok */ },
+      })
+    } catch (e) {
+      caught = e
+    }
+    expect(caught).toBe(original)
+  })
+})

--- a/xmcl-runtime/instanceIO/InstanceInstallService.ts
+++ b/xmcl-runtime/instanceIO/InstanceInstallService.ts
@@ -178,14 +178,6 @@ export class InstanceInstallService extends AbstractService implements IInstance
     const lockFilePath = join(instancePath, 'instance-lock.json')
     const currentStatePath = join(instancePath, '.install-profile')
 
-    const fileDelta: InstanceFileUpdate[] = await this.#getDelta(
-      instancePath,
-      lockState,
-      targetState.upstream,
-      targetState.files,
-    )
-    this.log('Instance install delta', fileDelta.length)
-
     const curseforgeClient = this.curseforgeClient
     const modrinthClient = this.modrinthClient
     const zipManager = await this.app.registry.getOrCreate(ZipManager)
@@ -199,6 +191,32 @@ export class InstanceInstallService extends AbstractService implements IInstance
 
     const lock = this.mutex.of(LockKey.instance(instancePath))
     const logger = this
+
+    // Track the task at service level. Created BEFORE the lock so the
+    // abort handler below has a stable controller to flip when
+    // deleteInstance fires while we're still waiting for the lock.
+    const task = this.tasks.create<InstallInstanceTask>({
+      type: 'installInstance',
+      key: `install-instance-${instancePath}`,
+      instancePath,
+      taskId: id,
+    })
+
+    // Race fix: deleteInstance and #install used to take different
+    // mutex keys, so `rm -rf <instance>` could run while our install
+    // was still writing files (ENOENT/EPERM/EBUSY storm on
+    // .install-profile / staging-dir rename). We now:
+    //   1. Register a strong-ref abort callback so deleteInstance can
+    //      cancel us fast (held to keep the closure alive — previously
+    //      handlers were WeakRef'd and could be GC'd mid-install).
+    //   2. Move every fs op into a single runExclusive on the same
+    //      LockKey.instance(p) that deleteInstance now waits on.
+    const instanceService = await this.app.registry.get(InstanceService)
+    const abortOnRemove = () => task.controller.abort()
+    const unregisterRemoveHandler = instanceService.registerRemoveHandler(
+      instancePath,
+      abortOnRemove,
+    )
 
     const updateResources = async () => {
       try {
@@ -239,157 +257,197 @@ export class InstanceInstallService extends AbstractService implements IInstance
       }
     }
 
-    // Track the task at service level
-    const task = this.tasks.create<InstallInstanceTask>({
-      type: 'installInstance',
-      key: `install-instance-${instancePath}`,
-      instancePath,
-      taskId: id,
-    })
-
     // Create tracker that updates task substate
     const tracker: Tracker<InstallInstanceTrackerEvents> = getTracker(task)
 
-    // Update handler context with tracker
-    const handlerWithTracker = new InstanceFileOperationHandlerV2(
-      instancePath,
-      new Set(targetState.finishedPath),
-      targetState.workspace,
-      targetState.backup,
-      {
-        worker: this.worker,
-        logger: this,
-        onSpecialFile: (file) => {
-          resourceToUpdate.push({
-            hash: file.hashes.sha1,
-            metadata: {
-              modrinth: file.modrinth,
-              curseforge: file.curseforge,
+    try {
+      await lock.runExclusive(async () => {
+        task.controller.signal.throwIfAborted()
+
+        // Persist pending-install marker INSIDE the lock so a
+        // concurrent deleteInstance cannot rm the parent dir
+        // mid-write (caller `installInstanceFiles` used to do this
+        // unlocked, which is one of the ENOENT-on-.install-profile
+        // shapes we saw in telemetry).
+        await writeJson(currentStatePath, InstanceInstallLock.parse(targetState))
+
+        const fileDelta: InstanceFileUpdate[] = await this.#getDelta(
+          instancePath,
+          lockState,
+          targetState.upstream,
+          targetState.files,
+        )
+        this.log('Instance install delta', fileDelta.length)
+        task.controller.signal.throwIfAborted()
+
+        // Update handler context with tracker
+        const handlerWithTracker = new InstanceFileOperationHandlerV2(
+          instancePath,
+          new Set(targetState.finishedPath),
+          targetState.workspace,
+          targetState.backup,
+          {
+            worker: this.worker,
+            logger: this,
+            onSpecialFile: (file) => {
+              resourceToUpdate.push({
+                hash: file.hashes.sha1,
+                metadata: {
+                  modrinth: file.modrinth,
+                  curseforge: file.curseforge,
+                },
+                uris: file.downloads || [],
+                destination: file.path,
+              })
             },
-            uris: file.downloads || [],
-            destination: file.path,
-          })
-        },
-        getCachedResource: (sha1) =>
-          this.resourceManager
-            .getSnapshotByHash(sha1)
-            .then((r) => (r ? this.resourceManager.validateSnapshotFile(r) : undefined))
-            .then((r) => r?.path),
-        getPeerActualUrl: (url) =>
-          this.app.registry
-            .getIfPresent(kPeerFacade)
-            .then((peers) => peers?.getHttpDownloadUrl(url)),
-        unzipFiles: (payloads, finished, signal) =>
-          unzipInstanceFiles(zipManager, payloads, finished, signal, tracker),
-        downloadFiles: (payloads, finished, signal) =>
-          downloadInstanceFiles(
-            payloads.map((v) => ({
-              options: {
-                url: v.options.urls,
-                validator: v.options.sha1 ? { algorithm: 'sha1', hash: v.options.sha1 } : undefined,
-                destination: v.options.destination,
-                expectedTotal: v.options.size,
-              },
-              file: v.file,
-            })),
-            finished,
-            signal,
-            downloadOptions,
-            tracker,
-          ),
-        linkFiles: (payloads, finished, unhandled, signal) =>
-          linkInstanceFiles(payloads, this.app.platform, finished, unhandled, signal, tracker),
-      },
-    )
-
-    const runInstallTasks = async () => {
-      try {
-        const newAddedFiles = fileDelta
-          .filter((f) => f.operation === 'add' || f.operation === 'backup-add')
-          .map((f) => f.file)
-
-        const hasUpdate = await resolveInstanceFiles(
-          newAddedFiles,
-          curseforgeClient,
-          modrinthClient,
-          task.controller.signal,
+            getCachedResource: (sha1) =>
+              this.resourceManager
+                .getSnapshotByHash(sha1)
+                .then((r) => (r ? this.resourceManager.validateSnapshotFile(r) : undefined))
+                .then((r) => r?.path),
+            getPeerActualUrl: (url) =>
+              this.app.registry
+                .getIfPresent(kPeerFacade)
+                .then((peers) => peers?.getHttpDownloadUrl(url)),
+            unzipFiles: (payloads, finished, signal) =>
+              unzipInstanceFiles(zipManager, payloads, finished, signal, tracker),
+            downloadFiles: (payloads, finished, signal) =>
+              downloadInstanceFiles(
+                payloads.map((v) => ({
+                  options: {
+                    url: v.options.urls,
+                    validator: v.options.sha1 ? { algorithm: 'sha1', hash: v.options.sha1 } : undefined,
+                    destination: v.options.destination,
+                    expectedTotal: v.options.size,
+                  },
+                  file: v.file,
+                })),
+                finished,
+                signal,
+                downloadOptions,
+                tracker,
+              ),
+            linkFiles: (payloads, finished, unhandled, signal) =>
+              linkInstanceFiles(payloads, this.app.platform, finished, unhandled, signal, tracker),
+          },
         )
 
-        if (hasUpdate) {
-          // save current state
-          logger.log('Save current state due to refresh', instancePath)
+        const runInstallTasks = async () => {
+          try {
+            const newAddedFiles = fileDelta
+              .filter((f) => f.operation === 'add' || f.operation === 'backup-add')
+              .map((f) => f.file)
+
+            const hasUpdate = await resolveInstanceFiles(
+              newAddedFiles,
+              curseforgeClient,
+              modrinthClient,
+              task.controller.signal,
+            )
+
+            if (hasUpdate) {
+              // save current state
+              logger.log('Save current state due to refresh', instancePath)
+              await writeJson(
+                currentStatePath,
+                InstanceInstallLock.parse({
+                  ...targetState,
+                  mtime: Date.now(),
+                }),
+              )
+            }
+          } catch {
+            // Ignore
+          }
+
+          try {
+            await handlerWithTracker.prepareInstallFiles(fileDelta, task.controller.signal)
+            logger.log('Finished install tasks')
+          } catch (e) {
+            logger.warn('Install instance files error', e)
+            // Guarded: if this writeJson itself fails (e.g. AV held
+            // the file, ENOSPC) we MUST keep the original `e` —
+            // previously the inner throw replaced it, which is why
+            // production telemetry only ever saw the generic
+            // "ENOENT open .install-profile" wrapper and never the
+            // real cause (download/zip/network).
+            await writeJson(
+              currentStatePath,
+              InstanceInstallLock.parse({
+                ...targetState,
+                finishedPath: Array.from(handlerWithTracker.finished),
+                mtime: Date.now(),
+              }),
+            ).catch((writeErr) => {
+              logger.warn('Failed to save partial install state', writeErr)
+            })
+            throw e
+          }
+
+          task.controller.signal.throwIfAborted()
+          await handlerWithTracker.backupAndRename()
+
+          await updateResources()
+        }
+
+        await runInstallTasks()
+
+        task.controller.signal.throwIfAborted()
+
+        // update the lock file
+        if (!noLock) {
           await writeJson(
-            currentStatePath,
-            InstanceInstallLock.parse({
-              ...targetState,
+            lockFilePath,
+            InstanceLockSchema.parse({
+              version: 1,
+              files: targetState.files,
+              upstream: targetState.upstream,
               mtime: Date.now(),
             }),
           )
         }
-      } catch {
-        // Ignore
-      }
 
-      try {
-        await handlerWithTracker.prepareInstallFiles(fileDelta, task.controller.signal)
-        logger.log('Finished install tasks')
-      } catch (e) {
-        logger.warn('Install instance files error', e)
-        await writeJson(
-          currentStatePath,
-          InstanceInstallLock.parse({
-            ...targetState,
-            finishedPath: Array.from(handlerWithTracker.finished),
-            mtime: Date.now(),
-          }),
-        )
-        throw e
-      }
+        // remove the install lock
+        await unlink(currentStatePath).catch(() => {
+          /* ignored */
+        })
 
-      await handlerWithTracker.backupAndRename()
-
-      await updateResources()
-    }
-
-    try {
-      await lock.runExclusive(async () => {
-        await runInstallTasks()
+        if (handlerWithTracker.unresolvable.length > 0) {
+          await writeFile(
+            join(instancePath, 'unresolved-files.json'),
+            JSON.stringify(handlerWithTracker.unresolvable),
+          )
+        }
       })
-
-      // update the lock file
-      if (!noLock) {
-        await writeJson(
-          lockFilePath,
-          InstanceLockSchema.parse({
-            version: 1,
-            files: targetState.files,
-            upstream: targetState.upstream,
-            mtime: Date.now(),
-          }),
-        )
-      }
-
-      // remove the install lock
-      await unlink(currentStatePath).catch(() => {
-        /* ignored */
-      })
-
-      if (handlerWithTracker.unresolvable.length > 0) {
-        await writeFile(
-          join(instancePath, 'unresolved-files.json'),
-          JSON.stringify(handlerWithTracker.unresolvable),
-        )
-      }
 
       task.complete()
     } catch (e) {
       task.fail(e as Error)
+      // AbortError = deleteInstance triggered our remove handler, or
+      // the user cancelled the task. ErrorDiagnose:118 already drops
+      // this from telemetry — DON'T rewrite the name, or it will
+      // resurface as InstallInstanceFilesError.
+      if ((e as any)?.name === 'AbortError') {
+        throw e
+      }
+      // async-mutex E_CANCELED: instanceLock.cancel() rejected us
+      // while we were queued behind a now-deleted instance. Same
+      // semantic as abort — surface as AbortError so the existing
+      // suppression catches it instead of a noisy
+      // InstallInstanceFilesError telemetry event.
+      if ((e as any)?.message === 'request for lock canceled') {
+        const cancelled = new Error('Install canceled by instance removal')
+        ;(cancelled as any).name = 'AbortError'
+        throw cancelled
+      }
       throw Object.assign(e as any, {
         name: (e as any).name === 'Error' ? 'InstallInstanceFilesError' : (e as any).name,
         installInstance: {
           instancePath,
         },
       })
+    } finally {
+      unregisterRemoveHandler()
     }
   }
 
@@ -572,8 +630,6 @@ export class InstanceInstallService extends AbstractService implements IInstance
         .then(InstanceLockSchema.parse)
         .catch(() => undefined)
 
-      const pendingInstallPath = join(instancePath, '.install-profile')
-
       const instanceDir = dirname(instancePath)
       const instanceName = basename(instancePath)
       const currentState: InstanceInstallLock = {
@@ -590,8 +646,9 @@ export class InstanceInstallService extends AbstractService implements IInstance
         finishedPath: [],
       }
 
-      // save current state
-      await writeJson(pendingInstallPath, InstanceInstallLock.parse(currentState))
+      // Note: the .install-profile marker is now written by #install
+      // INSIDE its instance-lock critical section, so a concurrent
+      // deleteInstance cannot rm the parent directory mid-write.
 
       this.log('Install instance files with lock', !!lockState)
       return this.#install(instancePath, lockState, currentState, id).catch((e) => {

--- a/xmcl-runtime/java/detectJVMArch.ts
+++ b/xmcl-runtime/java/detectJVMArch.ts
@@ -29,9 +29,15 @@ export async function getJavaArch(serv: JavaService, javaPath: string) {
     if (arch === '64') return 'x64'
     return arch
   } catch (e) {
+    // The JavaProxy invocation fails for environments whose JRE is
+    // already broken (Oracle java that can't find `lib/amd64/jvm.cfg`,
+    // SystemPath shim launched with the wrong working dir, etc.) and
+    // also when the JRE itself throws InvocationTargetException. None
+    // of these are launcher defects, so demote from `error` (→
+    // trackException storm in telemetry) to `warn` and skip the JRE.
     if (e instanceof Error) {
       if (!e.stack) e.stack = new Error().stack
-      serv.error(e)
+      serv.warn(`Failed to detect java arch for ${javaPath}: ${e.message}`)
     }
     return undefined
   }

--- a/xmcl-runtime/launch/pluginLaunchPrecheck.ts
+++ b/xmcl-runtime/launch/pluginLaunchPrecheck.ts
@@ -13,7 +13,7 @@ import { InstanceService } from '~/instance'
 import { JavaService, JavaValidation } from '~/java'
 import { LaunchService } from '~/launch'
 import { PeerService } from '~/peer'
-import { linkDirectory, missing } from '~/util/fs'
+import { linkOrCopyDirectory, missing } from '~/util/fs'
 
 export const pluginLaunchPrecheck: LauncherAppPlugin = async (app) => {
   const launchService = await app.registry.get(LaunchService)
@@ -21,6 +21,16 @@ export const pluginLaunchPrecheck: LauncherAppPlugin = async (app) => {
 
   const logger = app.getLogger('LaunchPrecheck')
 
+  // `libraries/` and `versions/` are read-mostly launcher-managed caches
+  // (the game only consumes them, the installer writes the source-of-truth
+  // copy). That matches the safety contract of `linkOrCopyDirectory`, so
+  // we use it here to recover the 2 856 ev / 423 users of `LaunchLinkError`
+  // on 0.56.4 that were caused by users without `SeCreateSymbolicLinkPrivilege`
+  // (no Windows Developer Mode, no admin) where both `symlink('dir')` and
+  // `symlink('junction')` fail with EPERM and the launch never gets the
+  // libraries it needs. See issue #1428 — the v0.56.4 fix was reverted from
+  // this call site (commit d34708ef) out of safety paranoia even though the
+  // doc on `linkOrCopyDirectory` explicitly endorses it for this case.
   const ensureLinkFolder = async (fromPath: string, toPath: string) => {
     if (await missing(fromPath)) {
       await ensureDir(fromPath)
@@ -30,7 +40,7 @@ export const pluginLaunchPrecheck: LauncherAppPlugin = async (app) => {
       // relink
       if (linkTarget !== fromPath) {
         await unlink(toPath).catch(() => {})
-        await linkDirectory(fromPath, toPath, logger).catch((e) => {
+        await linkOrCopyDirectory(fromPath, toPath, logger).catch((e) => {
           e.name = 'LaunchLinkError'
           e.stage = 'relink'
           logger.error(e)
@@ -43,7 +53,7 @@ export const pluginLaunchPrecheck: LauncherAppPlugin = async (app) => {
       throw e
     })
     if (!fstat) {
-      await linkDirectory(fromPath, toPath, logger).catch((e) => {
+      await linkOrCopyDirectory(fromPath, toPath, logger).catch((e) => {
         e.name = 'LaunchLinkError'
         e.stage = 'link'
         logger.error(e)
@@ -57,7 +67,7 @@ export const pluginLaunchPrecheck: LauncherAppPlugin = async (app) => {
         await move(toPath, join(toPath + Date.now() + '.bk'))
       }
     }
-    await linkDirectory(fromPath, toPath, logger).catch((e) => {
+    await linkOrCopyDirectory(fromPath, toPath, logger).catch((e) => {
       e.name = 'LaunchLinkError'
       e.stage = 'after move'
       logger.error(e)

--- a/xmcl-runtime/resource/pluginResourceWorker.ts
+++ b/xmcl-runtime/resource/pluginResourceWorker.ts
@@ -51,6 +51,9 @@ function loadDatabaseConfig(app: LauncherApp, flights: any) {
     if (e instanceof Error && e.name === 'SQLite3Error') {
       if (
         e.message === 'unable to open database file' ||
+        e.message === 'database disk image is malformed' ||
+        e.message === 'file is not a database' ||
+        e.message === 'file is encrypted or is not a database' ||
         e.message.startsWith('no such table') ||
         e.message.startsWith('out of memory')
       )
@@ -115,7 +118,7 @@ export const pluginResourceWorker: LauncherAppPlugin = async (app) => {
     if (db) {
       db.destroy()
       const dbPath = join(app.appDataPath, 'resources.sqlite')
-      const bkPath = dbPath + +'.' + Date.now() + '.bk'
+      const bkPath = dbPath + '.' + Date.now() + '.bk'
       await rename(dbPath, bkPath).catch(() => {})
     }
     const config = loadDatabaseConfig(app, flights)

--- a/xmcl-runtime/user/accountSystems/MicrosoftAccountSystem.ts
+++ b/xmcl-runtime/user/accountSystems/MicrosoftAccountSystem.ts
@@ -191,6 +191,17 @@ export class MicrosoftAccountSystem implements UserAccountSystem {
       // it as expected/transient so it doesn't pollute telemetry.
       if (e instanceof MicrosoftMinecraftXboxLoginError && e.retryable) return true
       if (typeof e?.message === 'string' && /status code: (?:408|429)/.test(e.message)) return true
+      // OAuth-layer error codes returned by MSAL / the Microsoft
+      // identity platform itself (not XBox XErr). `access_denied` =
+      // user denied consent; `server_error` / `invalid_request` /
+      // `consent_required` / `interaction_required` /
+      // `login_required` / `user_cancelled` = transient or user-driven.
+      // Telemetry showed 34 ev / 29 users in 0.56.4 even after #1445
+      // shipped the XErr mapping. Follow-up to that issue.
+      if (typeof e?.message === 'string' &&
+          /\b(access_denied|server_error|invalid_request|consent_required|interaction_required|login_required|user_cancelled)\b/.test(e.message)) {
+        return true
+      }
       return false
     }
     const logError = (e: any) => {


### PR DESCRIPTION
## Summary

Triage of `xmcl-client-insight` exceptions for **0.56.4** surfaced one P0
regression and a long tail of expected-state errors / small bugs that
were still spamming `trackException`. This branch rolls them into one
PR following the same "batch P*" pattern as #1447.

## Fixes

| Commit | Telemetry pattern (0.56.4) | Events / Users | Issue |
| --- | --- | --- | --- |
| `fix(resource): persist parseError on snapshots ...` | repeated parse-error toasts for known-broken mods | 鈥?| #1453 |
| `fix(sqlite): recover from on-disk corruption ...` | `database disk image is malformed` / `no such table: snapshots\|resources` storm | **13 014 / 7** | #1429 (regression) |
| `fix(telemetry): suppress 8 more expected-state errors ...` | AbortError, `.install-profile` ENOENT, MissingVersionJson, OptifineInstall ENOENT, InstanceDelete EBUSY, OAuth `access_denied\|server_error\|invalid_request`, native `Failed to open: ...`, JavaProxy `jvm.cfg` | 91/12, 59/15, 147/33, 21/14, 34/29, 57/22, 27/19, 24/20 | new tracking issue |
| `fix(ui): harden Fabric authors, decorateError, renderer telemetry filter` | `applyFabric authors?.map`, `decorateError` getter-only TypeError, `Key is required at getSWRV` | 21/1, 21/14, 23/11 | new tracking issue |
| `fix(install): ensure mods/ exists before copying OptiFine ...` | `OptifineInstallError ENOENT mods folder` | 21/5 | new tracking issue |

### 2026-06-06 follow-up batch (added after re-querying v0.56.4 telemetry)

| Commit | Telemetry pattern (0.56.4, 7d) | Events / Users | Issue |
| --- | --- | --- | --- |
| `fix(launch): use linkOrCopyDirectory in pluginLaunchPrecheck for libraries/versions` | `LaunchLinkError EPERM symlink` 鈥?v0.56.4's fallback was reverted from this call site (d34708ef) so users without `SeCreateSymbolicLinkPrivilege` still throw on every launch | **2 856 / 423** | #1428 (reopened) |
| `fix(telemetry): match real vue-i18n message shape + drop VChip isFixedPosition` | `SyntaxError: 24` from vue-i18n compileError 鈥?the v0.56.4 customDimensions instrumentation matched `SyntaxError: {"code":24}` which never fires in production, so locale/route landed empty for every event | **4 992 / 380** | #1427 |
| (same commit) | `TypeError: Failed to execute 'getComputedStyle' on 'Window': parameter 1 is not of type 'Element'.` 鈥?pure Vuetify VChip upstream, no app code in stack | **1 490 / 747** | #1426 |

The 2026-06-06 pass also confirmed:

* #1443 CurseForge fingerprints: **31 ev / 8 users** 鈫?effectively fixed by #1447, no new commit needed.
* #1446 NodeError `Controller is already closed`: **6 ev / 5 users** 鈫?fixed by #1447.
* #1445 MSAL OAuth-layer codes (`access_denied` 87/75, `server_error` 72/53, `invalid_request` 18/14): already covered by `e7bc29b6` (`ErrorDiagnose` lines 149-157) 鈥?will drop to ~0 as soon as this PR ships.
* #1429 SQLite `Database2._handleError` storm (9 787 ev / 28 users): covered by `8e92e236` (corruption recovery + `no such table` suppression).

## Validation

- `pnpm exec vitest run` 鈥?runtime: 47 passed (7 files); pre-existing suite: 746 passed / 16 skipped / 0 failed
- `pnpm check` 鈥?passes for runtime-api, runtime, keystone-ui (pre-existing
  `electron-builder` `CliOptions.publish` typing error in
  `xmcl-electron-app/build.ts` is unrelated to this PR)
- `pnpm lint` 鈥?only pre-existing unrelated warnings

## Severity guide (post-release verification KQL is in each linked issue)

The P0 here is the SQLite regression 鈥?at ~1860 events/user it is by far
the loudest signal in 0.56.4 telemetry. Everything else is either a P2
defect with a clear cause or a P2/P3 Exception conversion per the
[telemetry-triage runbook](../../knowledge/runbooks/telemetry-triage.md).


### 2026-06-06 follow-up batch (cont.) — InstallInstanceFilesError race fix

| Commit | Telemetry pattern (0.56.x, 14d) | Events / Users | Issue |
| --- | --- | --- | --- |
| `fix(install): eliminate deleteInstance / install race ...` (a39addd6) | `InstallInstanceFilesError` ENOENT/EPERM/EBUSY/EINVAL on `.install-profile` + `.<inst>-install-<ts>` rename + `request for lock canceled` | **~430 / ~115** combined | #1457 (follow-up comment) |

**Root cause** (re-investigated per @ci010's pushback on the "user/AV deleted it" diagnosis): `InstanceService.deleteInstance` used `LockKey.instanceRemove(p)` while `InstanceInstallService.#install` used `LockKey.instance(p)` — **different mutex keys**, so they never serialized. `async-mutex.cancel()` only rejects pending acquires; it does not abort the active holder. So `rm -rf <instance>` ran underneath in-flight installs → ENOENT/EPERM/EBUSY storm. Secondary bug: catch in `runInstallTasks` did `await writeJson(...)` without its own try/catch, so the inner ENOENT replaced the real install error — masking the true cause in every telemetry event.

**Fix**: `deleteInstance` now acquires the same `LockKey.instance(p)` (queued synchronously before any await, so it can't be racced by a new install); `#install` registers a strong-ref `task.controller.abort` callback via `registerRemoveHandler` (refactored from `WeakRef` to strong refs + returned unregister); critical section expanded to cover the full install lifecycle (pending-marker write, `#getDelta`, runInstallTasks, lockfile write, profile unlink, unresolved-files write); catch's inner `writeJson` `.catch`'d; AbortError / `request for lock canceled` no longer renamed.

**Tests**: 6 new cases in `xmcl-runtime/instance/deleteInstance.race.test.ts`. All 53 xmcl-runtime tests pass. Typecheck clean.
