### PR TITLE
fix: prevent dynamic override of macOS dock icon to preserve native squircle

### DIFF
--- a/xmcl-electron-app/main/controllers/tray.ts
+++ b/xmcl-electron-app/main/controllers/tray.ts
@@ -153,7 +153,6 @@ export const trayPlugin: ControllerPlugin = function (this: ElectronController) 
     tray.setContextMenu(createMenu())
 
     if (app.dock) {
-      app.dock.setIcon(nativeTheme.shouldUseDarkColors ? darkIcon : lightIcon)
       app.on('activate', () => {
         if (this.mainWin && !this.mainWin.isDestroyed()) {
           this.mainWin?.show()
@@ -169,9 +168,6 @@ export const trayPlugin: ControllerPlugin = function (this: ElectronController) 
   })
 
   this.app.on('app-booted', (man) => {
-    if (app.dock) {
-      app.dock.setIcon(nativeTheme.shouldUseDarkColors ? man.iconSets.darkDockIcon : man.iconSets.dockIcon)
-    }
     this.tray?.setImage(getTrayImage(man.iconSets.darkTrayIcon, man.iconSets.trayIcon))
   })
 }


### PR DESCRIPTION
This PR removes the programmatic dock icon override on app boot in order to allow macOS to properly apply its native padded squircle background to the dock icon. before whenever the app was opened, the standard icon shape was lost and it looked weird asf on the dock