### PR TITLE
feat: use native inset style for v-switch to match Material 3 guidelines

### DIFF
--- a/xmcl-keystone-ui/src/vuetify.ts
+++ b/xmcl-keystone-ui/src/vuetify.ts
@@ -50,6 +50,12 @@ export const vuetify = createVuetify({
     aliases,
     sets: { md, xmcl },
   },
+  defaults: {
+    VSwitch: {
+      inset: true,
+      color: 'primary',
+    },
+  },
   theme: {
     defaultTheme: 'dark',
     themes: {


### PR DESCRIPTION
globally configures Vuetify's VSwitch to use the native inset property, making it more modern looking