### PR TITLE
fix: restore localized world map preview tab in save details and improve error resilience

### DIFF
--- a/xmcl-keystone-ui/locales/uk.yaml
+++ b/xmcl-keystone-ui/locales/uk.yaml
@@ -1157,6 +1157,7 @@ save:
   gameMode: режим гри
   independent: Екземпляр використовує незалежну папку збережень
   levelName: Назва рівня
+  mapPreview: Карта світу
   name: Збереження | Збереження
   search: Шукати збереження
   seed: Seed

--- a/xmcl-keystone-ui/src/components/MarketProjectDetail.vue
+++ b/xmcl-keystone-ui/src/components/MarketProjectDetail.vue
@@ -256,7 +256,7 @@
 
     <v-tabs v-roving-tabindex role="tablist" v-model="tab" bg-color="transparent">
       <v-tab :value="0">
-        {{ t('modrinth.description') }}
+        {{ props.contentTabName || t('modrinth.description') }}
       </v-tab>
       <v-tab :value="1" :disabled="props.detail.galleries.length === 0">
         {{ t('modrinth.gallery') }}
@@ -671,6 +671,7 @@ const props = defineProps<{
   loadingCollections?: boolean
   collection?: string
   noPaddingContent?: boolean
+  contentTabName?: string
   /**
    * When set, shows an "add to collection" menu for the currently shown
    * provider's project. Enables adding both Modrinth and CurseForge projects

--- a/xmcl-keystone-ui/src/components/SaveWorldMap.vue
+++ b/xmcl-keystone-ui/src/components/SaveWorldMap.vue
@@ -344,15 +344,17 @@ async function ensureRegionLoaded(rx: number, rz: number) {
       atTop.value ? undefined : renderHeight.value,
     )
     chunkCache.set(key, chunks)
-    const buffer = data instanceof Uint8Array ? data : new Uint8Array(data as ArrayBufferLike)
+    const buffer = data instanceof Uint8Array ? data : new Uint8Array(data as any)
+    const clamped = new Uint8ClampedArray(buffer.buffer || buffer, buffer.byteOffset || 0, buffer.byteLength || buffer.length)
     const imageData = new ImageData(
-      new Uint8ClampedArray(buffer.buffer, buffer.byteOffset, buffer.byteLength) as any,
+      clamped,
       512,
       512,
     )
     const bitmap = await createImageBitmap(imageData)
     tileCache.set(key, bitmap)
   } catch (e) {
+    console.error('[SaveWorldMap] Failed to load region:', rx, rz, e)
     tileCache.set(key, 'empty')
   }
   requestRender()

--- a/xmcl-keystone-ui/src/views/SaveDetail.vue
+++ b/xmcl-keystone-ui/src/views/SaveDetail.vue
@@ -90,6 +90,7 @@ const onEnable = (enable: boolean) => {
     @delete="emit('delete', save.installed[0])"
     @enable="onEnable"
     no-padding-content
+    :content-tab-name="t('save.mapPreview')"
   >
     <template #content>
       <div class="save-map-wrapper">


### PR DESCRIPTION
Fixing:

<img width="1766" height="998" alt="image" src="https://github.com/user-attachments/assets/f2fe4cbd-6147-40cc-8768-0c5ed8a0d8c8" />



Bug reporter : https://discord.com/channels/405213567118213121/1109382903751782450/1529117242279858276