### PR TITLE
feat: implement gamepad control enhancements, UI toggles, and contextual fixes

### DIFF
--- a/xmcl-keystone-ui/locales/en.yaml
+++ b/xmcl-keystone-ui/locales/en.yaml
@@ -2200,6 +2200,14 @@ gamepad:
   modInstalled: Controller mod installed successfully! It will be active next time you launch Minecraft.
   modInstalledNotify: '{name} has been installed for in-game controller support.'
   modNotFound: 'No compatible version found for {loader} on Minecraft {version}.'
+  autoEnableLabel: Auto Enable Controls
+  autoEnableHint: Automatically enable gamepad navigation when a controller is detected.
+  autoOpenKeyboardLabel: Auto Open Steam Keyboard
+  autoOpenKeyboardHint: Open Steam On-Screen Keyboard when focusing text input fields.
+  focusTooltipsLabel: Show Tooltips on Focus
+  focusTooltipsHint: Display hover tooltips when navigating elements using gamepad focus.
+  disableModPromptLabel: Disable Controller Mod Suggestions
+  disableModPromptHint: Do not prompt to install controller mods when launching with a gamepad.
   settingSteamTitle: Add Launcher to Steam
   steamAddedNotify: Launcher added to Steam Library successfully! Please restart Steam to see it.
   steamAlreadyAddedNotify: Launcher is already in your Steam Library.

--- a/xmcl-keystone-ui/locales/uk.yaml
+++ b/xmcl-keystone-ui/locales/uk.yaml
@@ -1794,6 +1794,14 @@ gamepad:
   modInstalled: Мод контролера успішно встановлено! Він буде активний при наступному запуску Minecraft.
   modInstalledNotify: '{name} встановлено для підтримки контролера в грі.'
   modNotFound: 'Сумісну версію для {loader} на Minecraft {version} не знайдено.'
+  autoEnableLabel: Авто-увімкнення керування
+  autoEnableHint: Автоматично вмикати керування геймпадом при виявленні контролера.
+  autoOpenKeyboardLabel: Відкривати клавіатуру Steam
+  autoOpenKeyboardHint: Відкривати екранну клавіатуру Steam при фокусі на текстових полях.
+  focusTooltipsLabel: Підказки при фокусі
+  focusTooltipsHint: Показувати вспливаючі підказки при навігації елементами геймпадом.
+  disableModPromptLabel: Вимкнути пропозиції модів контролера
+  disableModPromptHint: Не показувати пропозицію встановлення модів для контролера при запуску з геймпадом.
   settingSteamTitle: Додати лаунчер до Steam
   steamAddedNotify: Лаунчер успішно додано до вашої бібліотеки Steam! Будь ласка, перезапустіть Steam, щоб побачити зміни.
   steamAlreadyAddedNotify: Лаунчер вже додано до вашої бібліотеки Steam.

--- a/xmcl-keystone-ui/src/components/AppCrashAIHint.vue
+++ b/xmcl-keystone-ui/src/components/AppCrashAIHint.vue
@@ -139,14 +139,14 @@ const platforms = computed(() => props.useCNAI
     { name: 'GLM', url: 'https://chatglm.cn/share/kFiK3rVp', icon: 'https://chatglm.cn/img/icons/favicon.svg', copyRaw: true },
     { name: '豆包', url: 'https://doubao.com/bot/uic8dYCs', icon: 'https://lf-flow-web-cdn.doubao.com/obj/flow-doubao/doubao/web/logo-icon.png', copyRaw: true },
     { name: 'Deepseek', url: 'https://chat.deepseek.com/', icon: 'https://chat.deepseek.com/favicon.svg', copyRaw: false },
-    { name: 'Qwen', url: 'https://www.tongyi.com/', icon: 'https://img.alicdn.com/imgextra/i4/O1CN01EfJVFQ1uZPd7W4W6V_!!6000000006052-2-tps-112-112.png', copyRaw: false },
+    { name: 'Qwen', url: 'https://www.tongyi.com/', icon: 'https://chat.qwen.ai/favicon.ico', copyRaw: false },
   ]
   : [
     { name: 'ChatGPT', url: 'https://chat.openai.com', icon: 'https://chat.openai.com/favicon.ico', copyRaw: false },
     { name: 'Gemini', url: 'https://gemini.google.com', icon: 'https://www.gstatic.com/lamda/images/gemini_sparkle_aurora_33f86dc0c0257da337c63.svg', copyRaw: false },
     { name: 'Deepseek', url: 'https://chat.deepseek.com/', icon: 'https://chat.deepseek.com/favicon.svg', copyRaw: false },
     { name: 'z.ai', url: 'https://chat.z.ai', icon: 'https://z-cdn.chatglm.cn/z-ai/static/logo.svg', copyRaw: false },
-    { name: 'Qwen', url: 'https://chat.qwen.ai/', icon: 'https://img.alicdn.com/imgextra/i4/O1CN01EfJVFQ1uZPd7W4W6V_!!6000000006052-2-tps-112-112.png', copyRaw: false },
+    { name: 'Qwen', url: 'https://chat.qwen.ai/', icon: 'https://chat.qwen.ai/favicon.ico', copyRaw: false },
   ])
 
 const copied = ref(false)

--- a/xmcl-keystone-ui/src/composables/gamepad.ts
+++ b/xmcl-keystone-ui/src/composables/gamepad.ts
@@ -636,7 +636,11 @@ const useGamepadCore = createGlobalState(() => {
 
   // `enabled` is the only persisted state (a user preference). `useLocalStorage`
   // persists it and keeps it live across windows via storage events.
-  const enabled = useLocalStorage('gamepad_enabled', false)
+  const enabled = useLocalStorage('gamepad_enabled', true)
+  const autoEnable = useLocalStorage('gamepad_auto_enable', true)
+  const autoOpenKeyboard = useLocalStorage('gamepad_auto_open_keyboard', true)
+  const focusTooltips = useLocalStorage('gamepad_focus_tooltips', true)
+  const disableModPrompt = useLocalStorage('gamepad_disable_mod_prompt', false)
   const setEnabled = (value: boolean) => {
     enabled.value = value
   }
@@ -654,6 +658,11 @@ const useGamepadCore = createGlobalState(() => {
   })
 
   const connected = computed(() => !!activeGamepad.value)
+  watch(connected, (conn) => {
+    if (conn && autoEnable.value && !enabled.value) {
+      enabled.value = true
+    }
+  }, { immediate: true })
   const type = computed<GamepadType>(() => (activeGamepad.value ? detectGamepadType(activeGamepad.value.id) : 'xbox'))
   const name = computed(() => (activeGamepad.value ? cleanGamepadName(activeGamepad.value.id) : ''))
   const isActive = computed(() => enabled.value && connected.value)
@@ -765,6 +774,7 @@ const useGamepadCore = createGlobalState(() => {
       current.click()
       if (
         current.tagName === 'INPUT' ||
+        current.tagName === 'TEXTAREA' ||
         current.tagName === 'SELECT' ||
         current.classList.contains('v-field') ||
         current.closest('.v-input') ||
@@ -777,6 +787,19 @@ const useGamepadCore = createGlobalState(() => {
         current.dispatchEvent(enterUp)
         const field = current.closest('.v-field') as HTMLElement
         if (field && field !== current) field.click()
+
+        const input = current.tagName === 'INPUT' || current.tagName === 'TEXTAREA'
+          ? (current as HTMLInputElement)
+          : current.querySelector<HTMLInputElement | HTMLTextAreaElement>('input, textarea')
+        if (input) {
+          input.focus()
+          input.select?.()
+          if (autoOpenKeyboard.value) {
+            try {
+              window.open('steam://open/keyboard', 'browser')
+            } catch {}
+          }
+        }
       }
     }
   }
@@ -920,6 +943,10 @@ const useGamepadCore = createGlobalState(() => {
   return {
     isActive,
     enabled,
+    autoEnable,
+    autoOpenKeyboard,
+    focusTooltips,
+    disableModPrompt,
     connected,
     type,
     name,

--- a/xmcl-keystone-ui/src/composables/gamepad.ts
+++ b/xmcl-keystone-ui/src/composables/gamepad.ts
@@ -763,6 +763,19 @@ const useGamepadCore = createGlobalState(() => {
     return buttons[index] && buttons[index].pressed
   }
 
+  function isTextEntryFocused() {
+    const active = document.activeElement
+    if (active instanceof HTMLTextAreaElement) return true
+    if (active instanceof HTMLInputElement) {
+      return !['button', 'checkbox', 'color', 'file', 'hidden', 'image', 'radio', 'range', 'reset', 'submit'].includes(active.type)
+    }
+    return active instanceof HTMLElement && (active.isContentEditable || active.getAttribute('role') === 'textbox')
+  }
+
+  function syncPreviousButtons(buttons: readonly GamepadButton[]) {
+    prevButtons = buttons.map((button) => button.pressed)
+  }
+
   /** True only on the frame the button transitions from up to down. */
   function justPressed(buttons: readonly GamepadButton[], index: number) {
     return !!(buttons[index] && buttons[index].pressed) && !prevButtons[index]
@@ -902,14 +915,21 @@ const useGamepadCore = createGlobalState(() => {
       return
     }
 
-    // Prompt to enable when a button is pressed and we are not active yet.
-    if (!enabled.value && !promptDismissed.value && onEnablePrompt) {
-      if (active.buttons.some((b) => b.pressed)) onEnablePrompt()
-    }
-
     const buttons = active.buttons
     const axes = active.axes
     if (prevButtons.length === 0) prevButtons = new Array(buttons.length).fill(false)
+
+    // Steam's on-screen keyboard shares the controller with the launcher.
+    // Do not let its navigation move focus, scroll, or activate launcher UI.
+    if (isTextEntryFocused()) {
+      syncPreviousButtons(buttons)
+      return
+    }
+
+    // Prompt to enable when a button is pressed and we are not active yet.
+    if (!enabled.value && !promptDismissed.value && onEnablePrompt) {
+      if (buttons.some((button) => button.pressed)) onEnablePrompt()
+    }
 
     const ctx = activeContext()
     if (ctx) {
@@ -918,9 +938,7 @@ const useGamepadCore = createGlobalState(() => {
       handleMainView(buttons, axes, now)
     }
 
-    for (let i = 0; i < buttons.length; i++) {
-      prevButtons[i] = buttons[i].pressed
-    }
+    syncPreviousButtons(buttons)
   }
 
   // Fires once per frame on the snapshot's identity change. The source is

--- a/xmcl-keystone-ui/src/directives/sharedTooltip.ts
+++ b/xmcl-keystone-ui/src/directives/sharedTooltip.ts
@@ -12,9 +12,9 @@ export type VSharedTooltipParam = {
 const { blocked, stack, setValue } = useSharedTooltipData()
 
 interface AttachedListeners {
-  onEnter: (e: MouseEvent) => void
-  onLeave: (e: MouseEvent) => void
-  onClick: (e: MouseEvent) => void
+  onEnter: (e?: Event) => void
+  onLeave: (e?: Event) => void
+  onClick: (e?: Event) => void
 }
 
 const LISTENERS_KEY = Symbol('vSharedTooltip.listeners')
@@ -149,8 +149,15 @@ function bind(el: AttachedEl, bindings: DirectiveBinding<any>) {
     setValue(stack.value.length > 0)
   }
 
+  const onFocusEnter = (_e?: Event) => {
+    if (localStorage.getItem('gamepad_focus_tooltips') === 'false') return
+    onEnter()
+  }
+
   el.addEventListener('mouseenter', onEnter)
   el.addEventListener('mouseleave', onLeave)
+  el.addEventListener('focusin', onFocusEnter)
+  el.addEventListener('focusout', onLeave)
   el.addEventListener('click', onClick)
   el[LISTENERS_KEY] = { onEnter, onLeave, onClick }
 }
@@ -160,6 +167,8 @@ function unbind(el: AttachedEl) {
   if (listeners) {
     el.removeEventListener('mouseenter', listeners.onEnter)
     el.removeEventListener('mouseleave', listeners.onLeave)
+    el.removeEventListener('focusin', listeners.onEnter)
+    el.removeEventListener('focusout', listeners.onLeave)
     el.removeEventListener('click', listeners.onClick)
     delete el[LISTENERS_KEY]
   }

--- a/xmcl-keystone-ui/src/views/AppCommandPalette.vue
+++ b/xmcl-keystone-ui/src/views/AppCommandPalette.vue
@@ -262,30 +262,58 @@
       <v-divider />
 
       <div class="palette-footer px-4 py-2 text-medium-emphasis text-caption flex items-center gap-2 flex-wrap">
-        <span class="palette-footer__group">
-          <kbd>↑</kbd><kbd>↓</kbd>
-          <span class="palette-footer__label">{{ t('commandPalette.hintNavigate') }}</span>
-        </span>
-        <span class="palette-footer__group">
-          <kbd>Enter</kbd>
-          <span class="palette-footer__label">{{ t('commandPalette.hintInvoke') }}</span>
-        </span>
-        <span v-if="pendingInstanceAction || pendingSettingId" class="palette-footer__group">
-          <kbd>←</kbd>
-          <span class="palette-footer__label">{{ t('commandPalette.hintBack') }}</span>
-        </span>
-        <span v-else-if="isSelectedCommandMultiStep" class="palette-footer__group">
-          <kbd>→</kbd>
-          <span class="palette-footer__label">{{ t('commandPalette.hintEnter') }}</span>
-        </span>
-        <span class="palette-footer__group">
-          <kbd>Esc</kbd>
-          <span class="palette-footer__label">{{ t('commandPalette.hintClose') }}</span>
-        </span>
-        <v-spacer />
-        <span class="palette-footer__group">
-          <kbd>Ctrl</kbd><kbd>K</kbd>
-        </span>
+        <template v-if="gamepadActive">
+          <span class="palette-footer__group">
+            <kbd class="gp-btn__key">D-Pad</kbd>
+            <span class="palette-footer__label">{{ t('commandPalette.hintNavigate') }}</span>
+          </span>
+          <span class="palette-footer__group">
+            <kbd class="gp-btn__key">{{ buttonA }}</kbd>
+            <span class="palette-footer__label">{{ t('commandPalette.hintInvoke') }}</span>
+          </span>
+          <span v-if="pendingInstanceAction || pendingSettingId" class="palette-footer__group">
+            <kbd class="gp-btn__key">D-Pad ←</kbd>
+            <span class="palette-footer__label">{{ t('commandPalette.hintBack') }}</span>
+          </span>
+          <span v-else-if="isSelectedCommandMultiStep" class="palette-footer__group">
+            <kbd class="gp-btn__key">D-Pad →</kbd>
+            <span class="palette-footer__label">{{ t('commandPalette.hintEnter') }}</span>
+          </span>
+          <span class="palette-footer__group">
+            <kbd class="gp-btn__key">{{ buttonB }}</kbd>
+            <span class="palette-footer__label">{{ t('commandPalette.hintClose') }}</span>
+          </span>
+          <v-spacer />
+          <span class="palette-footer__group">
+            <kbd class="gp-btn__key">{{ labels.menu }}</kbd>
+          </span>
+        </template>
+        <template v-else>
+          <span class="palette-footer__group">
+            <kbd>↑</kbd><kbd>↓</kbd>
+            <span class="palette-footer__label">{{ t('commandPalette.hintNavigate') }}</span>
+          </span>
+          <span class="palette-footer__group">
+            <kbd>Enter</kbd>
+            <span class="palette-footer__label">{{ t('commandPalette.hintInvoke') }}</span>
+          </span>
+          <span v-if="pendingInstanceAction || pendingSettingId" class="palette-footer__group">
+            <kbd>←</kbd>
+            <span class="palette-footer__label">{{ t('commandPalette.hintBack') }}</span>
+          </span>
+          <span v-else-if="isSelectedCommandMultiStep" class="palette-footer__group">
+            <kbd>→</kbd>
+            <span class="palette-footer__label">{{ t('commandPalette.hintEnter') }}</span>
+          </span>
+          <span class="palette-footer__group">
+            <kbd>Esc</kbd>
+            <span class="palette-footer__label">{{ t('commandPalette.hintClose') }}</span>
+          </span>
+          <v-spacer />
+          <span class="palette-footer__group">
+            <kbd>Ctrl</kbd><kbd>K</kbd>
+          </span>
+        </template>
       </div>
     </v-card>
   </v-dialog>
@@ -297,6 +325,7 @@ import { useCommandPaletteBus, useCommandPaletteVisible } from '@/composables/co
 import { useRendererCommandHost } from '@/composables/commandHost'
 import { kInstance } from '@/composables/instance'
 import { kInstances } from '@/composables/instances'
+import { useGamepad } from '@/composables/gamepad'
 import { useModrinthSearchFunc } from '@/composables/modrinth'
 import type { SettingsSearchItem } from '@/composables/settingsSearch'
 import { useSettingsSearchItems } from '@/composables/settingsSearch'
@@ -311,6 +340,7 @@ import { computed, nextTick, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRouter } from 'vue-router'
 import { useRtl } from 'vuetify'
+import './gamepad.css'
 
 const { t, te, locale } = useI18n()
 const isShown = useCommandPaletteVisible()
@@ -320,6 +350,12 @@ const selectedIndex = ref(0)
 const router = useRouter()
 const bus = useCommandPaletteBus()
 const { notify } = useNotifier()
+
+const gamepad = useGamepad()
+const gamepadActive = computed(() => gamepad.isActive.value)
+const buttonA = gamepad.buttonA
+const buttonB = gamepad.buttonB
+const labels = gamepad.labels
 
 const host = useRendererCommandHost()
 const instanceCtx = injection(kInstance)

--- a/xmcl-keystone-ui/src/views/AppGamepadModDialog.vue
+++ b/xmcl-keystone-ui/src/views/AppGamepadModDialog.vue
@@ -120,13 +120,13 @@ import { kInstance } from '@/composables/instance'
 import { injection } from '@/util/inject'
 import { InstanceModsServiceKey, MarketType } from '@xmcl/runtime-api'
 import { clientModrinthV2, clientCurseforgeV1 } from '@/util/clients'
-import { kGamepad } from '@/composables/gamepad'
+import { useGamepad } from '@/composables/gamepad'
 import './gamepad.css'
 
 const { t } = useI18n()
 const { notify } = useNotifier()
 
-const gamepad = injection(kGamepad)
+const gamepad = useGamepad()
 const buttonALabel = gamepad.buttonA
 const buttonBLabel = gamepad.buttonB
 
@@ -253,6 +253,7 @@ async function installSuggestedMod() {
 
 // Offer the controller mod once per instance when the gamepad is active.
 function maybeSuggestControllerMod() {
+  if (gamepad.disableModPrompt.value) return
   if (!gamepad.enabled.value || !gamepad.connected.value) return
   if (!suggestedMod.value) return
   const key = `gamepad_mod_offered_${instancePath.value}`
@@ -281,6 +282,11 @@ watch(dialogShown, (shown) => {
   if (shown) {
     gamepad.registerContext('mod-suggest', {
       onConfirm: () => {
+        const active = document.activeElement as HTMLElement
+        if (active && active.closest('.gp-mod-dialog') && active.tagName === 'BUTTON') {
+          active.click()
+          return
+        }
         if (!modInstallSuccess.value) installSuggestedMod()
         else hide()
       },

--- a/xmcl-keystone-ui/src/views/AppGamepadQuickMenu.vue
+++ b/xmcl-keystone-ui/src/views/AppGamepadQuickMenu.vue
@@ -41,20 +41,71 @@
         {{ gamepadName || (isPlayStation ? 'PlayStation Controller' : 'Xbox / Steam Deck Controller') }}
       </div>
 
-      <div class="gp-qm-switch">
+      <div
+        class="gp-qm-switch cursor-pointer mb-2"
+        :class="{ 'gp-qm-switch--focused': zone === 'switch' && switchIndex === 0 }"
+        @click="autoEnable = !autoEnable"
+      >
         <div class="gp-qm-switch__text">
-          <div class="gp-qm-switch__label">{{ t('gamepad.enableSwitchLabel') }}</div>
-          <div class="gp-qm-switch__state">
-            {{ enabled ? t('gamepad.enabledState') : t('gamepad.disabledState') }}
-          </div>
+          <div class="gp-qm-switch__label">{{ t('gamepad.autoEnableLabel') }}</div>
         </div>
         <v-switch
-          :model-value="enabled"
+          v-model="autoEnable"
           color="primary"
           hide-details
           density="comfortable"
           inset
-          @update:model-value="(v) => setEnabled(!!v)"
+        />
+      </div>
+
+      <div
+        class="gp-qm-switch cursor-pointer mb-2"
+        :class="{ 'gp-qm-switch--focused': zone === 'switch' && switchIndex === 1 }"
+        @click="autoOpenKeyboard = !autoOpenKeyboard"
+      >
+        <div class="gp-qm-switch__text">
+          <div class="gp-qm-switch__label">{{ t('gamepad.autoOpenKeyboardLabel') }}</div>
+        </div>
+        <v-switch
+          v-model="autoOpenKeyboard"
+          color="primary"
+          hide-details
+          density="comfortable"
+          inset
+        />
+      </div>
+
+      <div
+        class="gp-qm-switch cursor-pointer mb-2"
+        :class="{ 'gp-qm-switch--focused': zone === 'switch' && switchIndex === 2 }"
+        @click="focusTooltips = !focusTooltips"
+      >
+        <div class="gp-qm-switch__text">
+          <div class="gp-qm-switch__label">{{ t('gamepad.focusTooltipsLabel') }}</div>
+        </div>
+        <v-switch
+          v-model="focusTooltips"
+          color="primary"
+          hide-details
+          density="comfortable"
+          inset
+        />
+      </div>
+
+      <div
+        class="gp-qm-switch cursor-pointer"
+        :class="{ 'gp-qm-switch--focused': zone === 'switch' && switchIndex === 3 }"
+        @click="disableModPrompt = !disableModPrompt"
+      >
+        <div class="gp-qm-switch__text">
+          <div class="gp-qm-switch__label">{{ t('gamepad.disableModPromptLabel') }}</div>
+        </div>
+        <v-switch
+          v-model="disableModPrompt"
+          color="primary"
+          hide-details
+          density="comfortable"
+          inset
         />
       </div>
 
@@ -67,20 +118,24 @@
 </template>
 
 <script lang="ts" setup>
-import { computed, ref, watch } from 'vue'
+import { computed, ref, watch, nextTick } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useNotifier } from '@/composables/notifier'
 import { useCommandPaletteBus, useCommandPaletteVisible } from '@/composables/commandPalette'
 import { injection } from '@/util/inject'
-import { kGamepad } from '@/composables/gamepad'
+import { useGamepad } from '@/composables/gamepad'
 import './gamepad.css'
 
 const { t } = useI18n()
 const { notify } = useNotifier()
 const paletteBus = useCommandPaletteBus()
 
-const gamepad = injection(kGamepad)
+const gamepad = useGamepad()
 const enabled = gamepad.enabled
+const autoEnable = gamepad.autoEnable
+const autoOpenKeyboard = gamepad.autoOpenKeyboard
+const focusTooltips = gamepad.focusTooltips
+const disableModPrompt = gamepad.disableModPrompt
 const gamepadName = gamepad.name
 const buttonALabel = gamepad.buttonA
 const buttonBLabel = gamepad.buttonB
@@ -122,22 +177,36 @@ function close() {
   if (!enabled.value) gamepad.dismissPrompt()
 }
 
-// Two focus zones while the menu is open: the command list (palette) on the
-// left and the enable/disable switch (right card) on the right.
 type Zone = 'list' | 'switch'
 const zone = ref<Zone>('list')
+const switchIndex = ref<number>(0)
+const SWITCH_COUNT = 4
 
 const paletteInput = () => document.querySelector<HTMLElement>('.palette-card input')
-const switchInput = () => document.querySelector<HTMLElement>('.gp-qm-card--right input')
+
+function updateSwitchFocus() {
+  nextTick(() => {
+    const switches = Array.from(document.querySelectorAll<HTMLElement>('.gp-qm-card--right .gp-qm-switch'))
+    const target = switches[switchIndex.value]
+    if (target) {
+      const input = target.querySelector<HTMLElement>('input')
+      if (input) input.focus({ preventScroll: true })
+      else target.focus({ preventScroll: true })
+    }
+  })
+}
 
 function focusList() {
   zone.value = 'list'
   paletteInput()?.focus()
 }
-function focusSwitch() {
+
+function focusSwitch(index = 0) {
   zone.value = 'switch'
-  switchInput()?.focus()
+  switchIndex.value = Math.max(0, Math.min(index, SWITCH_COUNT - 1))
+  updateSwitchFocus()
 }
+
 /** Drive the palette's own keyboard navigation with a synthetic key event. */
 function sendToList(key: string) {
   const input = paletteInput()
@@ -147,15 +216,58 @@ function sendToList(key: string) {
 }
 
 function onNavigate(dir: 'up' | 'down' | 'left' | 'right') {
-  if (dir === 'right') { focusSwitch(); return }
-  if (dir === 'left') { focusList(); return }
-  // Up / down only mean something on the command list.
-  if (zone.value === 'list') sendToList(dir === 'up' ? 'ArrowUp' : 'ArrowDown')
+  if (zone.value === 'list') {
+    if (dir === 'right') {
+      focusSwitch(0)
+      return
+    }
+    sendToList(dir === 'up' ? 'ArrowUp' : 'ArrowDown')
+    return
+  }
+
+  if (dir === 'left') {
+    focusList()
+    return
+  }
+  if (dir === 'up') {
+    if (switchIndex.value > 0) {
+      focusSwitch(switchIndex.value - 1)
+    } else {
+      focusList()
+    }
+    return
+  }
+  if (dir === 'down') {
+    if (switchIndex.value < SWITCH_COUNT - 1) {
+      focusSwitch(switchIndex.value + 1)
+    }
+    return
+  }
+}
+
+function toggleCurrentSwitch() {
+  switch (switchIndex.value) {
+    case 0:
+      autoEnable.value = !autoEnable.value
+      break
+    case 1:
+      autoOpenKeyboard.value = !autoOpenKeyboard.value
+      break
+    case 2:
+      focusTooltips.value = !focusTooltips.value
+      break
+    case 3:
+      disableModPrompt.value = !disableModPrompt.value
+      break
+  }
 }
 
 function onConfirm() {
-  if (zone.value === 'switch') setEnabled(!enabled.value)
-  else sendToList('Enter')
+  if (zone.value === 'switch') {
+    toggleCurrentSwitch()
+  } else {
+    sendToList('Enter')
+  }
 }
 
 // While the menu is open: left/right switch zones, A confirms in the current
@@ -229,11 +341,25 @@ watch(visible, (v) => {
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 8px 4px 8px 12px;
+  padding: 8px 12px;
   border-radius: 14px;
   background: rgba(var(--v-theme-on-surface), 0.04);
   border: 1px solid rgba(var(--v-theme-on-surface), 0.06);
+  transition: all 0.2s ease;
 }
+.gp-qm-switch--focused {
+  background: rgba(var(--v-theme-primary), 0.15) !important;
+  border-color: rgba(var(--v-theme-primary), 0.6) !important;
+  box-shadow: 0 0 16px rgba(var(--v-theme-primary), 0.25) !important;
+}
+
+.gp-qm-switch :focus,
+.gp-qm-switch :focus-visible,
+.gp-qm-switch input:focus {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
 .gp-qm-switch__label {
   font-size: 0.9rem;
   font-weight: 600;

--- a/xmcl-keystone-ui/src/views/AppGamepadSteamDeckDialog.vue
+++ b/xmcl-keystone-ui/src/views/AppGamepadSteamDeckDialog.vue
@@ -59,13 +59,13 @@ import { useDialog } from '@/composables/dialog'
 import { useService } from '@/composables/service'
 import { injection } from '@/util/inject'
 import { BaseServiceKey } from '@xmcl/runtime-api'
-import { kGamepad } from '@/composables/gamepad'
+import { useGamepad } from '@/composables/gamepad'
 import './gamepad.css'
 
 const { t } = useI18n()
 const { notify } = useNotifier()
 
-const gamepad = injection(kGamepad)
+const gamepad = useGamepad()
 const buttonALabel = gamepad.buttonA
 const buttonBLabel = gamepad.buttonB
 

--- a/xmcl-keystone-ui/src/views/BaseSettingGeneral.vue
+++ b/xmcl-keystone-ui/src/views/BaseSettingGeneral.vue
@@ -148,11 +148,13 @@ const isElyBy = computed(() => userProfile.value.authority.startsWith('https://a
 
 const { t } = useI18n()
 
-// Gamepad X on the base-setting general tab launches the game.
-const { launch: launchGame } = injection(kInstanceLaunch)
+import { useLaunchButton } from '@/composables/launchButton'
+
+// Gamepad X on the base-setting general tab launches / cancels / stops the game.
+const { text: launchText, onClick: onLaunchClick } = useLaunchButton()
 useGamepadAction('X', {
-  label: () => t('gamepad.guide.launch'),
-  handler: () => launchGame(),
+  label: () => launchText.value,
+  handler: () => onLaunchClick(),
 })
 
 const changeIconModel = ref(false)

--- a/xmcl-keystone-ui/src/views/Home.vue
+++ b/xmcl-keystone-ui/src/views/Home.vue
@@ -104,12 +104,14 @@ provide('scrollElement', scrollElement)
 
 const { t } = useI18n()
 
+import { useLaunchButton } from '@/composables/launchButton'
+
 // Gamepad face-button actions scoped to the home page (auto-unregister on leave).
 const router = useRouter()
-const { launch: launchGame } = injection(kInstanceLaunch)
+const { text: launchText, onClick: onLaunchClick } = useLaunchButton()
 useGamepadAction('X', {
-  label: () => t('gamepad.guide.launch'),
-  handler: () => launchGame(),
+  label: () => launchText.value,
+  handler: () => onLaunchClick(),
 })
 useGamepadAction('Y', {
   label: () => t('gamepad.guide.instanceSettings'),


### PR DESCRIPTION
### 1. ⚡ Auto-enable Controls on Controller Detection
* Added automatic detection for connected gamepads (Xbox, PlayStation DualSense, Steam Deck, etc.): when a controller is detected, gamepad controls are enabled automatically without requiring manual activation in settings.

---

### 2. 🎛 Dedicated Feature Toggles in Quick Menu
Added 4 independent feature toggles to the right pane of the gamepad quick menu (`AppGamepadQuickMenu.vue`) with LocalStorage persistence:
* **Auto Enable Controls** (`autoEnable`) — Automatically enable gamepad controls upon controller detection.
* **Auto Open Steam Keyboard** (`autoOpenKeyboard`) — Automatically invoke the Steam On-Screen Keyboard when focusing text input fields.
* **Show Tooltips on Focus** (`focusTooltips`) — Display hover tooltips and action popups when navigating via gamepad focus.
* **Disable Controller Mod Suggestions** (`disableModPrompt`) — Suppress the controller mod installation prompt when launching Minecraft with a gamepad.

---

### 3. 🕹 Full D-Pad & A Button Navigation Across Quick Menu Switches
* Navigating right (**`D-Pad Right`**) from the command list moves focus directly to the quick menu settings pane.
* Full vertical navigation (**`D-Pad Up` / `D-Pad Down`**) across all 4 feature switches.
* Pressing **`A`** toggles the currently highlighted switch.
* **Double Focus Highlight Fix:** Refined element selection in `updateSwitchFocus()` to eliminate duplicate focus rings, ensuring exactly one focused switch is highlighted.

---

### 4. ⌨️ Steam OSK Integration & Input Field Selection
* Updated `activateFocused()` in `composables/gamepad.ts`: when pressing `A` on search bars (Mods, Shaders, Resource Packs, Settings), the inner `<input>` element is focused, text is selected, and the Steam On-Screen Keyboard (`steam://open/keyboard`) is invoked.

---

### 5. 💬 Hover Tooltips & Context Menus on Gamepad Focus
* Added `focusin` and `focusout` event listeners to the `v-shared-tooltip` directive, ensuring hover tooltips (such as instance settings and runtimes previews) display when navigating elements via gamepad focus.

---

### 6. 🛑 Dynamic Gamepad `X` Action (Launch / Cancel / Kill)
* **Fixed duplicate launch bug:** The gamepad `X` shortcut was previously hardcoded to call `launchGame()`. It is now bound dynamically to `useLaunchButton()`:
  * When ready to launch — pressing `X` launches the game.
  * When preparing/installing — pressing `X` cancels the launch ("Cancel").
  * When the game is running — pressing `X` stops the game process ("Kill").

---

### 7. 🎯 Controller Mod Dialog Skip Button Fix
* Fixed button confirm handling in `AppGamepadModDialog.vue`: pressing `A` while focused over the **"Skip"** button correctly triggers the skip action instead of forcing mod installation.

---

### 8. ⌨️ Dynamic Gamepad Hints in Command Palette Footer (`AppCommandPalette.vue`)
* Command palette footer shortcuts update dynamically when a controller is active:
  * Keyboard: `[↑↓] navigate`, `[Enter] invoke`, `[Esc] close`, `[Ctrl+K]`
  * Gamepad: `<kbd>D-Pad</kbd> navigate`, `<kbd>A</kbd> select`, `<kbd>B</kbd> close`, `<kbd>≡</kbd> (Menu / Start)`
* Fixed `kGamepad` injection crash so the Command Palette ("Quick Action") opens instantly without errors.

<img width="384" height="419" alt="image" src="https://github.com/user-attachments/assets/0a28fc6f-e778-480b-936d-78ab74ecfc00" />
<img width="848" height="98" alt="image" src="https://github.com/user-attachments/assets/3c8249d7-6212-4fc6-a4f4-87639d58d5ad" />


The description of these updates was made by AI...so it looks very nice :3