### PR TITLE
fix: unblock setup completion

### DIFF
--- a/xmcl-keystone-ui/src/views/Setup.vue
+++ b/xmcl-keystone-ui/src/views/Setup.vue
@@ -108,6 +108,7 @@
             <AppMoodSurface fill>
               <SetupAccount
                 v-model="data.instancePath"
+                :loading="data.loading"
                 @skip="setup"
               />
             </AppMoodSurface>
@@ -230,16 +231,12 @@ watch(() => data.theme, () => {
 
 const { state } = injection(kSettingsState)
 
-async function setup() {
-  await bootstrap.bootstrap(data.path)
+async function persistInitialTheme() {
   // The wizard mutates `currentTheme` in-place when it picks defaults
   // (dark mode + Halo background on GPU machines). `useTheme()` does not
   // auto-persist those mutations, so we must explicitly save here —
   // otherwise the first launch shows Halo but `theme.json` is never
   // written and the next launch falls back to `BackgroundType.NONE`.
-  //
-  // Await the environment lookup so the Halo assignment is in place
-  // before we serialize, instead of racing with the wizard unmounting.
   try {
     const e = await getEnvironment()
     if (e.gpu && isDark.value) {
@@ -253,6 +250,17 @@ async function setup() {
   } catch (err) {
     console.error('Failed to persist initial theme during setup', err)
   }
+}
+
+async function setup() {
+  if (data.loading) return
+  data.loading = true
+  try {
+    await bootstrap.bootstrap(data.path)
+  } catch (err) {
+    data.loading = false
+    throw err
+  }
   emit('ready', data)
   if (state.value) {
     state.value.localeSet(locale.value)
@@ -264,7 +272,9 @@ async function setup() {
       }
     })
   }
-  data.loading = true
+  // Environment detection may wait on the network. It should never block the
+  // user from leaving onboarding after the data root has been accepted.
+  void persistInitialTheme()
 }
 </script>
 

--- a/xmcl-keystone-ui/src/views/SetupAccount.vue
+++ b/xmcl-keystone-ui/src/views/SetupAccount.vue
@@ -23,6 +23,7 @@
         color="primary"
         variant="flat"
         rounded="xl"
+        :disabled="loading"
         @click="openAddAccountDialog"
       >
         <v-icon start>person_add</v-icon>
@@ -32,6 +33,7 @@
         data-testid="setup-account-skip"
         variant="tonal"
         rounded="xl"
+        :loading="loading"
         @click="emit('skip')"
       >
         {{ t('setup.account.skip') }}
@@ -43,6 +45,9 @@
 import UserAccountSwitcher from '@/components/UserAccountSwitcher.vue'
 import { useUserMenuControl } from '@/composables/userMenu'
 
+defineProps<{
+  loading?: boolean
+}>()
 const { show: showUserProfileDialog } = useUserMenuControl()
 const emit = defineEmits<{
   (event: 'skip'): void


### PR DESCRIPTION
## Summary

- leave onboarding as soon as the selected data root is accepted
- run GPU detection and initial theme persistence in the background so network delays cannot block the final step
- show loading state and guard against duplicate completion attempts from both `Skip for now` and `Start`

## Testing

- `pnpm check`
- `pnpm --prefix=xmcl-keystone-ui lint` (no errors; 2 existing warnings)
- `pnpm build:renderer`
- `pnpm --prefix=xmcl-electron-app compile`
- `pnpm test:e2e:scratch` (2 passed: skip and start paths)