### PR TITLE
fix(auth): resolve 24-hour Microsoft account reauthentication issue

### DIFF
--- a/xmcl-runtime/user/accountSystems/MicrosoftAccountSystem.ts
+++ b/xmcl-runtime/user/accountSystems/MicrosoftAccountSystem.ts
@@ -242,7 +242,7 @@ export class MicrosoftAccountSystem implements UserAccountSystem {
       }
       this.logger.error(Object.assign(e, { scenario: 'loginMicrosoft' }))
     }
-    const { result, extra } = await this.oauthClient.authenticate(microsoftEmailAddress, ['XboxLive.signin', 'XboxLive.offline_access'], {
+    const { result, extra } = await this.oauthClient.authenticate(microsoftEmailAddress, ['XboxLive.signin', 'XboxLive.offline_access', 'offline_access'], {
       code: oauthCode,
       useDeviceCode,
       directRedirectToLauncher,

--- a/xmcl-runtime/user/accountSystems/MicrosoftOAuthClient.ts
+++ b/xmcl-runtime/user/accountSystems/MicrosoftOAuthClient.ts
@@ -60,7 +60,7 @@ export class MicrosoftOAuthClient {
       },
       broker: nativeBrokerPlugin ? { nativeBrokerPlugin } : undefined,
       cache: {
-        cachePlugin: createPlugin('xmcl-oauth', account, this.logger, this.storage),
+        cachePlugin: createPlugin('xmcl-oauth', 'XMCL_MICROSOFT_ACCOUNT', this.logger, this.storage),
       },
       system: {
         loggerOptions: {
@@ -85,9 +85,9 @@ export class MicrosoftOAuthClient {
   } = {}) {
     const nativeBrokerPlugin = options.useNativeBroker ? await this.getNativeBrokerPlugin() : undefined
     const app = await this.getOAuthApp(username, options.signal, nativeBrokerPlugin)
-    if (username && !options?.code) {
+    if (!options?.code) {
       const accounts = await app.getTokenCache().getAllAccounts().catch(() => [])
-      const account = accounts.find(a => a.username === username)
+      const account = (username ? accounts.find(a => a.username.toLowerCase() === username.toLowerCase()) : undefined) || (accounts.length === 1 ? accounts[0] : undefined)
       if (account) {
         const result = await app.acquireTokenSilent({
           scopes,

--- a/xmcl-runtime/user/accountSystems/YggdrasilOCIDAuthClient.ts
+++ b/xmcl-runtime/user/accountSystems/YggdrasilOCIDAuthClient.ts
@@ -26,7 +26,7 @@ export class YggdrasilOCIDAuthClient {
         }
       },
       cache: {
-        cachePlugin: createPlugin('xmcl-oauth', account, this.logger, this.storage),
+        cachePlugin: createPlugin('xmcl-oauth', 'XMCL_MICROSOFT_ACCOUNT', this.logger, this.storage),
       },
       system: createNodeSystemOptions(this.logger, this.fetch, signal, true),
     })


### PR DESCRIPTION
## What's changing?

Fixes an annoying bug where Microsoft accounts force you to reauthenticate roughly every 24 hours instead of refreshing silently in the background.

## Why this was happening

1. **Cache key mismatch during token refresh**:
When you first log in, your username isn't known yet, so MSAL falls back to saving the token cache under `'XMCL_MICROSOFT_ACCOUNT'`. Later on, when the launcher attempts a silent refresh, it knows your email address and tries to load the cache using `user.username` instead. This caused a cache lookup miss, so MSAL thought there were no saved accounts and forced a full re-login. I fixed this by standardizing `cachePlugin` to always use `'XMCL_MICROSOFT_ACCOUNT'`.

2. **Missing `offline_access` scope**:
The scope list requested `XboxLive.signin` and `XboxLive.offline_access`, but missed the standard OIDC `offline_access` scope needed by Microsoft Entra ID / Azure AD to issue a refresh token in the first place.

3. **Case-sensitivity in account lookup**:
Updated the account lookup in MSAL to compare usernames case-insensitively (with a fallback to the single cached account if present) so minor string casing differences don't break silent refresh.

## Verification

Ran `pnpm check` and verified that everything compiles and passes type checks cleanly.