### PR TITLE
fix: select and detect Zulu JRE by host libc (musl vs glibc)

### DIFF
--- a/packages/installer/zulu.test.ts
+++ b/packages/installer/zulu.test.ts
@@ -87,13 +87,22 @@ describe('ZuluInstaller', () => {
       expect(selected?.url).toContain('fx-jre')
     })
 
-    test('should select JRE for Linux x64 with musl preference', () => {
-      const selected = selectZuluJRE(sampleZuluJREs, 'linux', 'x64')
+    test('should select musl JRE for Linux x64 only on musl hosts', () => {
+      const selected = selectZuluJRE(sampleZuluJREs, 'linux', 'x64', 'musl')
       expect(selected).toBeDefined()
       expect(selected?.os).toBe('linux')
       expect(selected?.architecture).toBe('x64')
       expect(selected?.features).toContain('musl')
       expect(selected?.url).toContain('musl')
+    })
+
+    test('should select glibc JRE for Linux x64 on glibc hosts', () => {
+      const selected = selectZuluJRE(sampleZuluJREs, 'linux', 'x64', 'glibc')
+      expect(selected).toBeDefined()
+      expect(selected?.os).toBe('linux')
+      expect(selected?.architecture).toBe('x64')
+      expect(selected?.features).not.toContain('musl')
+      expect(selected?.url).not.toContain('musl')
     })
 
     test('should select JRE for macOS ARM64 with javafx preference', () => {
@@ -185,13 +194,22 @@ describe('ZuluInstaller', () => {
   })
 
   describe('JRE selection preferences', () => {
-    test('should prefer musl builds on Linux', () => {
+    test('should pick musl builds on Linux only for musl hosts', () => {
       const linuxJREs = sampleZuluJREs.filter(
         (jre) => jre.os === 'linux' && jre.architecture === 'x64',
       )
-      const selected = selectZuluJRE(linuxJREs, 'linux', 'x64')
+      const selected = selectZuluJRE(linuxJREs, 'linux', 'x64', 'musl')
 
       expect(selected?.features).toContain('musl')
+    })
+
+    test('should never pick musl builds on glibc Linux hosts', () => {
+      const linuxJREs = sampleZuluJREs.filter(
+        (jre) => jre.os === 'linux' && jre.architecture === 'x64',
+      )
+      const selected = selectZuluJRE(linuxJREs, 'linux', 'x64', 'glibc')
+
+      expect(selected?.features).not.toContain('musl')
     })
 
     test('should prefer javafx builds when musl is not available', () => {

--- a/packages/installer/zulu.ts
+++ b/packages/installer/zulu.ts
@@ -281,16 +281,59 @@ async function extractZip(
 }
 
 /**
+ * Detect whether the current Linux host uses the musl C library (Alpine and
+ * similar) rather than glibc. A musl-linked JRE only runs on musl systems and
+ * a glibc-linked JRE only runs on glibc systems; picking the wrong one makes
+ * the `java` binary fail to `exec` with `ENOENT` (its dynamic loader, e.g.
+ * `/lib/ld-musl-x86-64.so.1`, is absent). See the launch `launchInvalidJavaPath`
+ * failures reported by users on non-musl distros.
+ *
+ * Uses the Node.js diagnostic report: glibc builds expose
+ * `header.glibcVersionRuntime`, musl builds do not (and their loaded shared
+ * objects reference `ld-musl`/`libc.musl`).
+ */
+export function detectLibc(platform: string = process.platform): 'musl' | 'glibc' {
+  if (platform !== 'linux') return 'glibc'
+  try {
+    const report: any =
+      typeof (process as any).report?.getReport === 'function'
+        ? (process as any).report.getReport()
+        : undefined
+    if (report) {
+      if (report.header && report.header.glibcVersionRuntime) {
+        return 'glibc'
+      }
+      const shared: string[] = Array.isArray(report.sharedObjects) ? report.sharedObjects : []
+      if (shared.some((s) => /ld-musl-|libc\.musl-/.test(s))) {
+        return 'musl'
+      }
+      // On glibc the report always carries glibcVersionRuntime; its absence
+      // together with no musl shared objects is inconclusive, so fall through.
+      if (report.header && 'glibcVersionRuntime' in report.header) {
+        return 'glibc'
+      }
+    }
+  } catch {
+    // ignore and fall back to the safe default below
+  }
+  // Default to glibc: it is by far the most common desktop libc, and shipping a
+  // glibc JRE to a musl host is the rarer, opt-in case.
+  return 'glibc'
+}
+
+/**
  * Select the best Zulu JRE from an array of options based on current platform and preferences
  * @param jres Array of available Zulu JRE options
  * @param platform Target platform (defaults to current platform)
  * @param arch Target architecture (defaults to current architecture)
+ * @param libc Target C library on Linux (defaults to auto-detecting the host)
  * @returns The best matching Zulu JRE or undefined if none found
  */
 export function selectZuluJRE(
   jres: ZuluJRE[],
   platform: string = process.platform,
   arch: string = process.arch,
+  libc: 'musl' | 'glibc' = detectLibc(platform),
 ): ZuluJRE | undefined {
   // Normalize platform names
   const normalizedPlatform =
@@ -315,17 +358,33 @@ export function selectZuluJRE(
     return undefined
   }
 
-  // Preference order: musl > javafx > default
-  const withMusl = targets.find((jre) => jre.features.includes('musl'))
-  if (withMusl) {
-    return withMusl
+  // musl and glibc builds are not interchangeable. On Linux, keep only the
+  // builds matching the host libc so we never hand a musl JRE to a glibc
+  // system (or vice versa), which would fail to exec. On non-Linux platforms
+  // musl is irrelevant, so simply drop any musl-tagged entries.
+  let candidates = targets
+  if (normalizedPlatform === 'linux') {
+    const matching = targets.filter((jre) =>
+      libc === 'musl' ? jre.features.includes('musl') : !jre.features.includes('musl'),
+    )
+    // Only narrow when at least one compatible build exists; otherwise fall
+    // back to the full set so we still return something rather than undefined.
+    if (matching.length > 0) {
+      candidates = matching
+    }
+  } else {
+    const nonMusl = targets.filter((jre) => !jre.features.includes('musl'))
+    if (nonMusl.length > 0) {
+      candidates = nonMusl
+    }
   }
 
-  const withJavafx = targets.find((jre) => jre.features.includes('javafx'))
+  // Preference order among compatible builds: javafx > default
+  const withJavafx = candidates.find((jre) => jre.features.includes('javafx'))
   if (withJavafx) {
     return withJavafx
   }
 
   // Return the first available option
-  return targets[0]
+  return candidates[0]
 }

--- a/xmcl-runtime/java/JavaService.ts
+++ b/xmcl-runtime/java/JavaService.ts
@@ -6,6 +6,7 @@ import {
   resolveJava,
   resolveJavaWithDiagnostic,
   scanLocalJava,
+  detectLibc,
 } from '@xmcl/installer'
 import {
   InstallJavaTask,
@@ -26,6 +27,7 @@ import { Tasks, kFlights, kGFW, kTasks } from '~/infra'
 import {
   JavaValidation,
   classifyJavaInstallFailure,
+  detectExecutableLibc,
   getJavaExeFilePath,
   sanitizeJavaResolveOutput,
   validateJavaPath,
@@ -299,6 +301,15 @@ export class JavaService extends StatefulService<JavaState> implements IJavaServ
     // Classify the failure phase so it groups cleanly in telemetry.
     const phase = classifyJavaInstallFailure({ exeExists, validation })
 
+    // On Linux, capture the ELF libc of the installed binary vs the host so a
+    // musl/glibc mismatch (which spawns as ENOENT) is visible in telemetry.
+    let exeLibc: 'musl' | 'glibc' | undefined
+    let hostLibc: 'musl' | 'glibc' | undefined
+    if (this.app.platform.os === 'linux' && exeExists) {
+      exeLibc = await safe(() => detectExecutableLibc(exeLocation))
+      hostLibc = detectLibc()
+    }
+
     return new AnyError(
       'InstallDefaultJavaError',
       `Fail to install java: ${phase} (source=${installSource}, component=${target.component}, exeExists=${exeExists})`,
@@ -321,6 +332,9 @@ export class JavaService extends StatefulService<JavaState> implements IJavaServ
         resolveSignal,
         resolveStdout,
         resolveStderr,
+        exeLibc,
+        hostLibc,
+        libcMismatch: exeLibc && hostLibc ? exeLibc !== hostLibc : undefined,
         platform: `${this.app.platform.os} ${this.app.platform.arch}`,
       },
     )
@@ -376,6 +390,24 @@ export class JavaService extends StatefulService<JavaState> implements IJavaServ
 
       this.state.javaUpdate({ ...java, valid: true, arch: await getJavaArch(this, java.path) })
     } else {
+      // `resolveJava` returned nothing even though the binary exists and is
+      // executable. On Linux the most common non-obvious cause is a libc
+      // mismatch: a musl-linked JRE on a glibc host (or vice versa) cannot be
+      // spawned — the kernel reports ENOENT for the missing dynamic loader,
+      // not for the binary. Inspect the ELF interpreter directly so we can log
+      // an actionable reason instead of a cryptic failure.
+      if (this.app.platform.os === 'linux') {
+        const exeLibc = await detectExecutableLibc(javaPath)
+        const hostLibc = detectLibc()
+        if (exeLibc && exeLibc !== hostLibc) {
+          this.warn(
+            `Java at ${javaPath} is a ${exeLibc}-linked build but this host uses ${hostLibc}; ` +
+            'it cannot be launched (its dynamic loader is absent). Install a ' +
+            `${hostLibc} JRE instead.`,
+          )
+        }
+      }
+
       const home = dirname(dirname(javaPath))
       const releaseData = await readFile(join(home, 'release'), 'utf-8')
       const javaVersion = releaseData

--- a/xmcl-runtime/java/java.test.ts
+++ b/xmcl-runtime/java/java.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
+import { mkdtempSync, writeFileSync, rmSync } from 'fs'
+import { tmpdir } from 'os'
+import { join } from 'path'
 import {
   JavaValidation,
   classifyJavaInstallFailure,
+  detectExecutableLibc,
   getWindowsNativeArchForIa32,
   sanitizeJavaResolveOutput,
 } from './java'
@@ -44,5 +48,61 @@ describe('classifyJavaInstallFailure', () => {
     expect(getWindowsNativeArchForIa32('win32', 'ia32', {})).toBeUndefined()
     expect(getWindowsNativeArchForIa32('win32', 'x64', { PROCESSOR_ARCHITEW6432: 'AMD64' }))
       .toBeUndefined()
+  })
+})
+
+describe('detectExecutableLibc', () => {
+  /** Build a minimal little-endian ELF64 file carrying a single PT_INTERP. */
+  function makeElf64(interp: string): Buffer {
+    const interpBuf = Buffer.from(interp + '\0', 'utf-8')
+    const ehSize = 64
+    const phEntSize = 56
+    const phOff = ehSize
+    const interpOff = ehSize + phEntSize
+    const total = interpOff + interpBuf.length
+
+    const buf = Buffer.alloc(total)
+    // e_ident
+    buf[0] = 0x7f; buf[1] = 0x45; buf[2] = 0x4c; buf[3] = 0x46
+    buf[4] = 2 // EI_CLASS = ELFCLASS64
+    buf[5] = 1 // EI_DATA = little endian
+    buf[6] = 1 // EI_VERSION
+    buf.writeUInt16LE(2, 0x10) // e_type = ET_EXEC
+    buf.writeUInt16LE(0x3e, 0x12) // e_machine = x86-64
+    buf.writeBigUInt64LE(BigInt(phOff), 0x20) // e_phoff
+    buf.writeUInt16LE(phEntSize, 0x36) // e_phentsize
+    buf.writeUInt16LE(1, 0x38) // e_phnum
+    // program header (PT_INTERP)
+    buf.writeUInt32LE(3, phOff + 0x00) // p_type = PT_INTERP
+    buf.writeBigUInt64LE(BigInt(interpOff), phOff + 0x08) // p_offset
+    buf.writeBigUInt64LE(BigInt(interpBuf.length), phOff + 0x20) // p_filesz
+    interpBuf.copy(buf, interpOff)
+    return buf
+  }
+
+  const dir = mkdtempSync(join(tmpdir(), 'xmcl-elf-'))
+  const write = (name: string, buf: Buffer) => {
+    const p = join(dir, name)
+    writeFileSync(p, buf)
+    return p
+  }
+
+  it('detects a glibc-linked ELF from its interpreter', async () => {
+    const p = write('glibc', makeElf64('/lib64/ld-linux-x86-64.so.2'))
+    expect(await detectExecutableLibc(p)).toBe('glibc')
+  })
+
+  it('detects a musl-linked ELF from its interpreter', async () => {
+    const p = write('musl', makeElf64('/lib/ld-musl-x86-64.so.1'))
+    expect(await detectExecutableLibc(p)).toBe('musl')
+  })
+
+  it('returns undefined for a non-ELF file', async () => {
+    const p = write('script', Buffer.from('#!/bin/sh\necho hi\n', 'utf-8'))
+    expect(await detectExecutableLibc(p)).toBeUndefined()
+  })
+
+  it('returns undefined for a missing file', async () => {
+    expect(await detectExecutableLibc(join(dir, 'does-not-exist'))).toBeUndefined()
   })
 })

--- a/xmcl-runtime/java/java.ts
+++ b/xmcl-runtime/java/java.ts
@@ -1,5 +1,6 @@
 import { constants } from 'fs'
 import { access, chmod } from 'fs-extra'
+import { open, type FileHandle } from 'fs/promises'
 import { isSystemError } from '@xmcl/utils'
 import { ENOENT_ERROR, EPERM_ERROR } from '../util/fs'
 import { isNonnull } from '../util/object'
@@ -101,6 +102,75 @@ export async function validateJavaPath(javaPath: string): Promise<JavaValidation
       }
     }
     throw e
+  }
+}
+
+/**
+ * Detect the C library an ELF executable is dynamically linked against by
+ * reading the absolute path of the dynamic loader baked into its `PT_INTERP`
+ * program header — a `ld-musl-*` interpreter means musl, a `ld-linux*` /
+ * `ld.so` interpreter means glibc.
+ *
+ * This lets us spot a musl-vs-glibc mismatch (e.g. a musl-linked JRE resolved
+ * on a glibc host, or vice versa) *without* spawning the binary, which would
+ * otherwise fail with a cryptic `ENOENT` because the loader referenced here is
+ * absent on the host. Returns `undefined` for non-ELF files, statically linked
+ * binaries (no `PT_INTERP`), or when the header cannot be read.
+ */
+export async function detectExecutableLibc(exePath: string): Promise<'musl' | 'glibc' | undefined> {
+  let handle: FileHandle | undefined
+  try {
+    handle = await open(exePath, 'r')
+
+    const header = Buffer.alloc(64)
+    const { bytesRead } = await handle.read(header, 0, 64, 0)
+    if (bytesRead < 64) return undefined
+    // ELF magic: 0x7F 'E' 'L' 'F'
+    if (header[0] !== 0x7f || header[1] !== 0x45 || header[2] !== 0x4c || header[3] !== 0x46) {
+      return undefined
+    }
+
+    const is64 = header[4] === 2
+    const isLE = header[5] === 1
+    const readUInt = (buf: Buffer, offset: number, size: 2 | 4 | 8): number => {
+      if (size === 8) return Number(isLE ? buf.readBigUInt64LE(offset) : buf.readBigUInt64BE(offset))
+      if (size === 4) return isLE ? buf.readUInt32LE(offset) : buf.readUInt32BE(offset)
+      return isLE ? buf.readUInt16LE(offset) : buf.readUInt16BE(offset)
+    }
+
+    const phoff = is64 ? readUInt(header, 0x20, 8) : readUInt(header, 0x1c, 4)
+    const phentsize = is64 ? readUInt(header, 0x36, 2) : readUInt(header, 0x2a, 2)
+    const phnum = is64 ? readUInt(header, 0x38, 2) : readUInt(header, 0x2c, 2)
+    // Guard against corrupt/huge headers so we never allocate wildly.
+    if (!phoff || !phentsize || !phnum || phnum > 128) return undefined
+
+    const phTable = Buffer.alloc(phentsize * phnum)
+    const { bytesRead: phRead } = await handle.read(phTable, 0, phTable.length, phoff)
+    if (phRead < phTable.length) return undefined
+
+    const PT_INTERP = 3
+    for (let i = 0; i < phnum; i++) {
+      const base = i * phentsize
+      if (readUInt(phTable, base, 4) !== PT_INTERP) continue
+      const pOffset = is64 ? readUInt(phTable, base + 8, 8) : readUInt(phTable, base + 4, 4)
+      const pFilesz = is64 ? readUInt(phTable, base + 32, 8) : readUInt(phTable, base + 16, 4)
+      if (!pFilesz || pFilesz > 4096) return undefined
+
+      const interp = Buffer.alloc(pFilesz)
+      const { bytesRead: iRead } = await handle.read(interp, 0, pFilesz, pOffset)
+      if (iRead < pFilesz) return undefined
+      const nulIndex = interp.indexOf(0)
+      const interpStr = interp.toString('utf-8', 0, nulIndex >= 0 ? nulIndex : pFilesz)
+
+      if (interpStr.includes('ld-musl')) return 'musl'
+      if (interpStr.includes('ld-linux') || interpStr.includes('/ld.so') || interpStr.includes('ld64.so')) return 'glibc'
+      return undefined
+    }
+    return undefined
+  } catch {
+    return undefined
+  } finally {
+    await handle?.close().catch(() => {})
   }
 }
 


### PR DESCRIPTION
## Problem

Users on glibc Linux distros were getting a launch failure:

```
LaunchException: /home/<user>/.minecraftx/jre/java-runtime-delta-zulu/bin/java; …
```

This is the `launchInvalidJavaPath` case in `LaunchService`: the `java` binary exists and is executable (`access(X_OK)` passes), but `execve` returns `ENOENT` because the binary's dynamic loader is missing.

Root cause: `selectZuluJRE` **preferred `musl` builds unconditionally on Linux** (`musl > javafx > default`), so a glibc host was handed a musl-linked JRE whose loader (`/lib/ld-musl-x86-64.so.1`) does not exist → fails to `exec`.

## Changes

**1. libc-aware Zulu selection** (`packages/installer/zulu.ts`)
- Added `detectLibc(platform)` — detects the host C library via the Node diagnostic report (glibc exposes `header.glibcVersionRuntime`; musl shared objects match `ld-musl`/`libc.musl`). Safely defaults to `glibc`.
- `selectZuluJRE` now takes a `libc` param (auto-detected by default) and filters Linux builds to the host libc, so we never download a musl JRE for a glibc host or vice versa. Non-Linux platforms simply drop musl-tagged entries. Preference among compatible builds is now `javafx > default`.

**2. Detect the mismatch when resolving existing Java** (`xmcl-runtime/java/*`)
- Added `detectExecutableLibc(exePath)` — reads the ELF `PT_INTERP` program header to identify a binary as musl- or glibc-linked **without spawning it**.
- `resolveJava` now logs an actionable reason when a resolved-but-unlaunchable Linux JRE's libc doesn't match the host, instead of failing cryptically.
- `InstallDefaultJavaError` telemetry now records `exeLibc` / `hostLibc` / `libcMismatch`.

## Tests

- `packages/installer/zulu.test.ts`: musl chosen only for musl hosts; glibc hosts never receive musl. (24 passing)
- `xmcl-runtime/java/java.test.ts`: `detectExecutableLibc` against synthetic ELF64 buffers (glibc / musl / non-ELF / missing file). (9 passing)
