### PR TITLE
fix(runtime): preserve existing Steam shortcuts

### DIFF
--- a/xmcl-runtime/app/BaseService.ts
+++ b/xmcl-runtime/app/BaseService.ts
@@ -11,7 +11,7 @@ import {
   DownloadUpdateTask,
   NetworkStatus,
 } from '@xmcl/runtime-api'
-import { readFile, readdir, stat, pathExists, writeFile } from 'fs-extra'
+import { readFile, readdir, stat, pathExists } from 'fs-extra'
 import os, { freemem, totalmem } from 'os'
 import { join, resolve } from 'path'
 import { Inject, LauncherAppKey, kGameDataPath } from '~/app'
@@ -26,6 +26,8 @@ import { LauncherApp } from '../app/LauncherApp'
 import { HAS_DEV_SERVER } from '../constant'
 import { ZipFile } from 'yazl'
 import { getTracker } from '~/util/taskHelper'
+import { addSteamShortcutToVdf } from './steamShortcut'
+import { writeFile as writeAtomically } from 'atomically'
 
 @ExposeServiceKey(BaseServiceKey)
 export class BaseService extends AbstractService implements IBaseService {
@@ -82,7 +84,10 @@ export class BaseService extends AbstractService implements IBaseService {
               (g) => g.vendorId === 4318 || g.vendorId === 4098 || g.vendorId === 4203,
             ) ?? false,
         ),
-      steamDeck: process.env.STEAM_DECK === '1' || process.env.USER === 'deck' || (process.platform === 'linux' && os.release().toLowerCase().includes('steamdeck')),
+      steamDeck:
+        process.env.STEAM_DECK === '1' ||
+        process.env.USER === 'deck' ||
+        (process.platform === 'linux' && os.release().toLowerCase().includes('steamdeck')),
     }
   }
 
@@ -100,88 +105,6 @@ export class BaseService extends AbstractService implements IBaseService {
   }
 
   async addSteamShortcut(): Promise<boolean> {
-    const parseBinaryVdf = (buffer: Buffer): any => {
-      let offset = 0
-      const readString = (): string => {
-        const start = offset
-        while (offset < buffer.length && buffer[offset] !== 0) {
-          offset++
-        }
-        const str = buffer.toString('utf8', start, offset)
-        offset++ // skip null terminator
-        return str
-      }
-
-      const parseMap = (): Record<string, any> => {
-        const obj: Record<string, any> = {}
-        while (offset < buffer.length) {
-          const type = buffer[offset]
-          if (type === 0x08) {
-            offset++ // skip 0x08
-            break
-          }
-          offset++ // skip type byte
-          const key = readString()
-          if (type === 0x00) {
-            obj[key] = parseMap()
-          } else if (type === 0x01) {
-            obj[key] = readString()
-          } else if (type === 0x02) {
-            obj[key] = buffer.readInt32LE(offset)
-            offset += 4
-          }
-        }
-        return obj
-      }
-
-      if (buffer.length === 0) return {}
-      const type = buffer[0]
-      if (type !== 0x00) return {}
-      offset++
-      const rootKey = readString()
-      const rootValue = parseMap()
-      return { [rootKey]: rootValue }
-    }
-
-    const serializeBinaryVdf = (obj: Record<string, any>): Buffer => {
-      const chunks: Buffer[] = []
-      const writeString = (str: string) => {
-        chunks.push(Buffer.from(str, 'utf8'))
-        chunks.push(Buffer.from([0]))
-      }
-
-      const serializeMap = (map: Record<string, any>) => {
-        for (const [key, value] of Object.entries(map)) {
-          if (value === null || value === undefined) continue
-          if (typeof value === 'object') {
-            chunks.push(Buffer.from([0x00]))
-            writeString(key)
-            serializeMap(value)
-          } else if (typeof value === 'string') {
-            chunks.push(Buffer.from([0x01]))
-            writeString(key)
-            writeString(value)
-          } else if (typeof value === 'number') {
-            chunks.push(Buffer.from([0x02]))
-            writeString(key)
-            const buf = Buffer.alloc(4)
-            buf.writeInt32LE(value, 0)
-            chunks.push(buf)
-          }
-        }
-        chunks.push(Buffer.from([0x08]))
-      }
-
-      const rootKeys = Object.keys(obj)
-      if (rootKeys.length > 0) {
-        const rootKey = rootKeys[0]
-        chunks.push(Buffer.from([0x00]))
-        writeString(rootKey)
-        serializeMap(obj[rootKey])
-      }
-      return Buffer.concat(chunks)
-    }
-
     // Find Steam userdata directory
     const steamPaths: string[] = []
     if (process.platform === 'win32') {
@@ -205,6 +128,7 @@ export class BaseService extends AbstractService implements IBaseService {
     const startDir = resolve(exePath, '..')
 
     let shortcutAdded = false
+    let shortcutError: unknown
 
     for (const steamPath of steamPaths) {
       const userdataPath = join(steamPath, 'userdata')
@@ -216,59 +140,32 @@ export class BaseService extends AbstractService implements IBaseService {
               const configDir = join(userdataPath, userDir, 'config')
               if (await pathExists(configDir)) {
                 const shortcutsVdfPath = join(configDir, 'shortcuts.vdf')
-                let data: any = { shortcuts: {} }
+                const existing = (await pathExists(shortcutsVdfPath))
+                  ? await readFile(shortcutsVdfPath)
+                  : Buffer.alloc(0)
+                const updated = addSteamShortcutToVdf(existing, {
+                  executable: `"${exePath}"`,
+                  startDir: `"${startDir}"`,
+                  icon: exePath,
+                })
 
-                if (await pathExists(shortcutsVdfPath)) {
-                  try {
-                    const buf = await readFile(shortcutsVdfPath)
-                    data = parseBinaryVdf(buf)
-                    if (!data || !data.shortcuts) {
-                      data = { shortcuts: {} }
-                    }
-                  } catch (e) {
-                    data = { shortcuts: {} }
-                  }
-                }
-
-                const existingList = Object.values(data.shortcuts)
-                const alreadyExists = existingList.some(
-                  (s: any) => s && (s.AppName === 'X Minecraft Launcher' || s.AppName === 'XMCL')
-                )
-
-                if (!alreadyExists) {
-                  const nextIdx = Object.keys(data.shortcuts).length.toString()
-                  data.shortcuts[nextIdx] = {
-                    AppName: 'X Minecraft Launcher',
-                    Exe: exePath,
-                    StartDir: `"${startDir}"`,
-                    icon: exePath,
-                    ShortcutPath: '',
-                    LaunchOptions: '',
-                    IsHidden: 0,
-                    AllowDesktopConfig: 1,
-                    AllowOverlay: 1,
-                    OpenVR: 0,
-                    Devkit: 0,
-                    DevkitGameID: '',
-                    DevkitOverrideAppID: 0,
-                    LastPlayTime: 0,
-                    FlatpakAppID: '',
-                    tags: {
-                      '0': 'Launcher'
-                    }
-                  }
-
-                  const updatedBuf = serializeBinaryVdf(data)
-                  await writeFile(shortcutsVdfPath, updatedBuf)
+                if (updated) {
+                  await writeAtomically(shortcutsVdfPath, updated)
                   shortcutAdded = true
                 }
               }
             }
           }
         } catch (err) {
-          // ignore error for individual folders
+          this.logger.warn(`Failed to add Steam shortcut for ${steamPath}`)
+          this.logger.warn(err)
+          shortcutError ??= err
         }
       }
+    }
+
+    if (!shortcutAdded && shortcutError) {
+      throw shortcutError
     }
 
     return shortcutAdded
@@ -355,9 +252,11 @@ export class BaseService extends AbstractService implements IBaseService {
       operation: updateInfo.operation as 'autoupdater' | 'asar' | 'appx' | 'manual',
       version: updateInfo.name,
     })
-    await task.wrap(this.app.updater.downloadUpdate(updateInfo, {
-      tracker: getTracker(task),
-    }))
+    await task.wrap(
+      this.app.updater.downloadUpdate(updateInfo, {
+        tracker: getTracker(task),
+      }),
+    )
     settings.updateStatusSet('ready')
   }
 

--- a/xmcl-runtime/app/steamShortcut.test.ts
+++ b/xmcl-runtime/app/steamShortcut.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from 'vitest'
+import { addSteamShortcutToVdf } from './steamShortcut'
+
+function string(key: string, value: string) {
+  return Buffer.from([0x01, ...Buffer.from(`${key}\0${value}\0`)])
+}
+
+function object(key: string, value: Buffer) {
+  return Buffer.concat([Buffer.from([0x00]), Buffer.from(`${key}\0`), value, Buffer.from([0x08])])
+}
+
+function existingShortcuts() {
+  const shortcut = Buffer.concat([
+    string('AppName', 'Existing non-Steam game'),
+    Buffer.from([0x09, ...Buffer.from('ByteFlag\0'), 0x7f]),
+    Buffer.from([0x0a, ...Buffer.from('AllowOverlay\0')]),
+  ])
+  return Buffer.concat([
+    Buffer.from([0x00, ...Buffer.from('shortcuts\0')]),
+    object('0', shortcut),
+    Buffer.from([0x08]),
+  ])
+}
+
+describe('addSteamShortcutToVdf', () => {
+  const shortcut = {
+    executable: '"/home/deck/X Minecraft Launcher"',
+    startDir: '"/home/deck"',
+    icon: '/home/deck/X Minecraft Launcher',
+  }
+
+  test('appends a shortcut without rewriting existing binary-VDF entries', () => {
+    const existing = existingShortcuts()
+
+    const updated = addSteamShortcutToVdf(existing, shortcut)
+
+    expect(updated).toBeDefined()
+    expect(updated!.subarray(0, existing.length - 1)).toEqual(
+      existing.subarray(0, existing.length - 1),
+    )
+    expect(updated![updated!.length - 1]).toBe(0x08)
+    expect(updated!.toString('utf8')).toContain('X Minecraft Launcher')
+  })
+
+  test('does not add a second launcher shortcut', () => {
+    const launcher = object('0', string('AppName', 'X Minecraft Launcher'))
+    const existing = Buffer.concat([
+      Buffer.from([0x00, ...Buffer.from('shortcuts\0')]),
+      launcher,
+      Buffer.from([0x08]),
+    ])
+
+    expect(addSteamShortcutToVdf(existing, shortcut)).toBeUndefined()
+  })
+
+  test('rejects malformed VDF instead of replacing it', () => {
+    expect(() =>
+      addSteamShortcutToVdf(
+        Buffer.from([0x00, ...Buffer.from('shortcuts\0'), 0x02, ...Buffer.from('appid\0')]),
+        shortcut,
+      ),
+    ).toThrow('Unexpected end')
+  })
+})

--- a/xmcl-runtime/app/steamShortcut.ts
+++ b/xmcl-runtime/app/steamShortcut.ts
@@ -1,0 +1,220 @@
+const VDF_OBJECT = 0x00
+const VDF_STRING = 0x01
+const VDF_INT32 = 0x02
+const VDF_FLOAT = 0x03
+const VDF_POINTER = 0x04
+const VDF_WSTRING = 0x05
+const VDF_COLOR = 0x06
+const VDF_UINT64 = 0x07
+const VDF_END = 0x08
+const VDF_COMPILED_INT_BYTE = 0x09
+const VDF_COMPILED_INT_0 = 0x0a
+const VDF_COMPILED_INT_1 = 0x0b
+
+export interface SteamShortcut {
+  executable: string
+  startDir: string
+  icon: string
+}
+
+interface ParsedShortcuts {
+  endOffset: number
+  entries: Array<{
+    name: string
+    appName?: string
+  }>
+}
+
+interface Cursor {
+  buffer: Buffer
+  offset: number
+}
+
+function readByte(cursor: Cursor): number {
+  if (cursor.offset >= cursor.buffer.length) {
+    throw new Error('Unexpected end of Steam shortcuts.vdf')
+  }
+  return cursor.buffer[cursor.offset++]
+}
+
+function readCString(cursor: Cursor): string {
+  const end = cursor.buffer.indexOf(0, cursor.offset)
+  if (end === -1) {
+    throw new Error('Unterminated string in Steam shortcuts.vdf')
+  }
+  const value = cursor.buffer.toString('utf8', cursor.offset, end)
+  cursor.offset = end + 1
+  return value
+}
+
+function skipBytes(cursor: Cursor, length: number) {
+  if (cursor.offset + length > cursor.buffer.length) {
+    throw new Error('Unexpected end of Steam shortcuts.vdf')
+  }
+  cursor.offset += length
+}
+
+function skipWideString(cursor: Cursor) {
+  while (cursor.offset + 1 < cursor.buffer.length) {
+    if (cursor.buffer.readUInt16LE(cursor.offset) === 0) {
+      cursor.offset += 2
+      return
+    }
+    cursor.offset += 2
+  }
+  throw new Error('Unterminated wide string in Steam shortcuts.vdf')
+}
+
+function skipMap(
+  cursor: Cursor,
+  onEntry?: (type: number, key: string, valueOffset: number) => void,
+) {
+  while (true) {
+    const type = readByte(cursor)
+    if (type === VDF_END) return
+
+    const key = readCString(cursor)
+    const valueOffset = cursor.offset
+    onEntry?.(type, key, valueOffset)
+    skipValue(cursor, type)
+  }
+}
+
+function skipValue(cursor: Cursor, type: number) {
+  switch (type) {
+    case VDF_OBJECT:
+      skipMap(cursor)
+      return
+    case VDF_STRING:
+      readCString(cursor)
+      return
+    case VDF_INT32:
+    case VDF_FLOAT:
+    case VDF_POINTER:
+    case VDF_COLOR:
+      skipBytes(cursor, 4)
+      return
+    case VDF_WSTRING:
+      skipWideString(cursor)
+      return
+    case VDF_UINT64:
+      skipBytes(cursor, 8)
+      return
+    case VDF_COMPILED_INT_BYTE:
+      skipBytes(cursor, 1)
+      return
+    case VDF_COMPILED_INT_0:
+    case VDF_COMPILED_INT_1:
+      return
+    default:
+      throw new Error(`Unsupported VDF value type ${type} in Steam shortcuts.vdf`)
+  }
+}
+
+function parseShortcuts(buffer: Buffer): ParsedShortcuts {
+  const cursor: Cursor = { buffer, offset: 0 }
+  if (readByte(cursor) !== VDF_OBJECT || readCString(cursor) !== 'shortcuts') {
+    throw new Error('Steam shortcuts.vdf does not contain a shortcuts root map')
+  }
+
+  const entries: ParsedShortcuts['entries'] = []
+  while (true) {
+    const type = readByte(cursor)
+    if (type === VDF_END) {
+      return { endOffset: cursor.offset, entries }
+    }
+
+    const name = readCString(cursor)
+    if (type !== VDF_OBJECT) {
+      skipValue(cursor, type)
+      continue
+    }
+
+    let appName: string | undefined
+    skipMap(cursor, (entryType, key, valueOffset) => {
+      if (entryType === VDF_STRING && key.toLowerCase() === 'appname') {
+        const valueCursor: Cursor = { buffer, offset: valueOffset }
+        appName = readCString(valueCursor)
+      }
+    })
+    entries.push({ name, appName })
+  }
+}
+
+function writeCString(chunks: Buffer[], value: string) {
+  chunks.push(Buffer.from(value, 'utf8'))
+  chunks.push(Buffer.from([0]))
+}
+
+function writeString(chunks: Buffer[], key: string, value: string) {
+  chunks.push(Buffer.from([VDF_STRING]))
+  writeCString(chunks, key)
+  writeCString(chunks, value)
+}
+
+function writeInt32(chunks: Buffer[], key: string, value: number) {
+  chunks.push(Buffer.from([VDF_INT32]))
+  writeCString(chunks, key)
+  const integer = Buffer.alloc(4)
+  integer.writeInt32LE(value)
+  chunks.push(integer)
+}
+
+function writeObject(chunks: Buffer[], key: string, write: () => void) {
+  chunks.push(Buffer.from([VDF_OBJECT]))
+  writeCString(chunks, key)
+  write()
+  chunks.push(Buffer.from([VDF_END]))
+}
+
+function serializeShortcut(index: number, shortcut: SteamShortcut): Buffer {
+  const chunks: Buffer[] = []
+  writeObject(chunks, index.toString(), () => {
+    writeString(chunks, 'AppName', 'X Minecraft Launcher')
+    writeString(chunks, 'Exe', shortcut.executable)
+    writeString(chunks, 'StartDir', shortcut.startDir)
+    writeString(chunks, 'icon', shortcut.icon)
+    writeString(chunks, 'ShortcutPath', '')
+    writeString(chunks, 'LaunchOptions', '')
+    writeInt32(chunks, 'IsHidden', 0)
+    writeInt32(chunks, 'AllowDesktopConfig', 1)
+    writeInt32(chunks, 'AllowOverlay', 1)
+    writeInt32(chunks, 'OpenVR', 0)
+    writeInt32(chunks, 'Devkit', 0)
+    writeString(chunks, 'DevkitGameID', '')
+    writeInt32(chunks, 'DevkitOverrideAppID', 0)
+    writeInt32(chunks, 'LastPlayTime', 0)
+    writeString(chunks, 'FlatpakAppID', '')
+    writeObject(chunks, 'tags', () => {
+      writeString(chunks, '0', 'Launcher')
+    })
+  })
+  return Buffer.concat(chunks)
+}
+
+export function addSteamShortcutToVdf(buffer: Buffer, shortcut: SteamShortcut): Buffer | undefined {
+  const parsed = buffer.length === 0 ? { endOffset: 0, entries: [] } : parseShortcuts(buffer)
+
+  if (
+    parsed.entries.some(({ appName }) => appName === 'X Minecraft Launcher' || appName === 'XMCL')
+  ) {
+    return undefined
+  }
+
+  const entryNames = new Set(parsed.entries.map(({ name }) => name))
+  let index = 0
+  while (entryNames.has(index.toString())) {
+    index += 1
+  }
+
+  const entry = serializeShortcut(index, shortcut)
+  if (buffer.length === 0) {
+    const root: Buffer[] = [Buffer.from([VDF_OBJECT])]
+    writeCString(root, 'shortcuts')
+    root.push(entry, Buffer.from([VDF_END]))
+    return Buffer.concat(root)
+  }
+
+  const rootEndOffset = parsed.endOffset - 1
+  return Buffer.concat([buffer.subarray(0, rootEndOffset), entry, buffer.subarray(rootEndOffset)])
+}


### PR DESCRIPTION
## Summary
- preserve existing `shortcuts.vdf` entries byte-for-byte when adding XMCL
- use atomic writes and surface malformed-VDF errors instead of replacing shortcut data
- quote the launcher executable path and add regression coverage

## Testing
- `pnpm exec vitest run xmcl-runtime/app/steamShortcut.test.ts`
- `pnpm --prefix=xmcl-runtime check`
- `pnpm --prefix=xmcl-runtime lint`