### PR TITLE
ci: use trusted publishing for core packages

### DIFF
--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
 
     if: ${{ startsWith(github.event.head_commit.message, 'chore(release)') }}
 
@@ -23,6 +26,8 @@ jobs:
       with:
         node-version: 22
         registry-url: 'https://registry.npmjs.org'
+    - name: Use npm with trusted publishing support
+      run: npm install --global npm@^11.15.0
     - name: Install
       run: |
         pnpm install --frozen-lockfile
@@ -36,10 +41,37 @@ jobs:
         pnpm --parallel build:browser
     - name: Publish
       run: |
-        pnpm -r --filter './packages/**' publish --access public --no-git-checks
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+        node <<'NODE'
+        const { execFileSync } = require('node:child_process')
+        const { existsSync, readdirSync, readFileSync } = require('node:fs')
+        const { join } = require('node:path')
+
+        for (const entry of readdirSync('packages', { withFileTypes: true })) {
+          if (!entry.isDirectory()) continue
+
+          const directory = join('packages', entry.name)
+          const packageJson = join(directory, 'package.json')
+          if (!existsSync(packageJson)) continue
+
+          const pkg = JSON.parse(readFileSync(packageJson, 'utf8'))
+          if (pkg.private) continue
+
+          try {
+            execFileSync('npm', [
+              'view',
+              `${pkg.name}@${pkg.version}`,
+              'version',
+              '--registry=https://registry.npmjs.org',
+            ], { stdio: 'ignore' })
+            console.log(`Skipping ${pkg.name}@${pkg.version}; it is already published.`)
+          } catch {
+            execFileSync('npm', ['publish', '--access=public', '--ignore-scripts'], {
+              cwd: directory,
+              stdio: 'inherit',
+            })
+          }
+        }
+        NODE
     - name: Build Docs
       run: |
         pnpm build:docs

--- a/packages/asm/package.json
+++ b/packages/asm/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/bore/package.json
+++ b/packages/bore/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/bytebuffer/package.json
+++ b/packages/bytebuffer/package.json
@@ -40,7 +40,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/curseforge/package.json
+++ b/packages/curseforge/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/discord-rpc/package.json
+++ b/packages/discord-rpc/package.json
@@ -26,7 +26,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "bugs": {
     "url": "https://github.com/Voxelum/minecraft-launcher-core-node/issues"

--- a/packages/file-transfer/package.json
+++ b/packages/file-transfer/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "sideEffects": false,
   "author": "cijhn@hotmail.com",

--- a/packages/forge-site-parser/package.json
+++ b/packages/forge-site-parser/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/game-data/package.json
+++ b/packages/game-data/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/gamesetting/package.json
+++ b/packages/gamesetting/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/installer/package.json
+++ b/packages/installer/package.json
@@ -30,7 +30,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "sideEffects": false,
   "author": "cijhn@hotmail.com",

--- a/packages/mod-parser/package.json
+++ b/packages/mod-parser/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "sideEffects": false,

--- a/packages/model/package.json
+++ b/packages/model/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "sideEffects": false,
   "author": "cijhn@hotmail.com",

--- a/packages/modrinth/package.json
+++ b/packages/modrinth/package.json
@@ -22,7 +22,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/nat-api/package.json
+++ b/packages/nat-api/package.json
@@ -40,7 +40,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/voxelum/nat-api.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "bugs": {
     "url": "https://github.com/voxelum/nat-api/issues"

--- a/packages/nbt/package.json
+++ b/packages/nbt/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/resourcepack/package.json
+++ b/packages/resourcepack/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/schematic/package.json
+++ b/packages/schematic/package.json
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/semver/package.json
+++ b/packages/semver/package.json
@@ -19,7 +19,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -15,7 +15,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "devDependencies": {
     "@types/node": "^24.13.3",

--- a/packages/system/package.json
+++ b/packages/system/package.json
@@ -26,7 +26,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [

--- a/packages/text-component/package.json
+++ b/packages/text-component/package.json
@@ -18,7 +18,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "sideEffects": false,

--- a/packages/unzip/package.json
+++ b/packages/unzip/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "sideEffects": false,

--- a/packages/user/package.json
+++ b/packages/user/package.json
@@ -25,7 +25,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Voxelum/minecraft-launcher-core-node.git"
+    "url": "git+https://github.com/Voxelum/x-minecraft-launcher.git"
   },
   "author": "cijhn@hotmail.com",
   "keywords": [


### PR DESCRIPTION
Migrates Core Package Publish to npm Trusted Publishing.

- Requests a GitHub OIDC token and removes the static npm publish token.
- Uses npm 11.15+ for OIDC-aware publishing.
- Publishes only packages without `private: true`, skipping already-published versions.
- Aligns all public package repository metadata with this repository for npm trusted-publisher verification.