### PR TITLE
fix: use configured token for core docs deployment

### DIFF
--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -81,4 +81,4 @@ jobs:
         target_branch: gh-pages
         build_dir: docs/
       env:
-        GITHUB_PAT: ${{ secrets.GITHUB_PAT }}
+        GITHUB_PAT: ${{ secrets.PAT_GITHUB_TOKEN }}


### PR DESCRIPTION
Restores the GitHub Pages deployment after Core Package Publish succeeds.

The workflow referenced the nonexistent `GITHUB_PAT` secret; the repository's configured secret is `PAT_GITHUB_TOKEN`.