### PR TITLE
feat: add host-star multiplayer v2 client

### DIFF
--- a/packages/wrtc-multiplayer/lib/PeerContext.ts
+++ b/packages/wrtc-multiplayer/lib/PeerContext.ts
@@ -11,9 +11,15 @@ export interface PeerContext {
 
   onIdentity(session: string, info: ConnectionUserInfo): void
   onInstanceShared(session: string, manifest?: InstanceManifest): void
-  onDescriptorUpdate(session: string, sdp: string, type: string, candidates: Array<{ candidate: string; mid: string }>): void
+  onDescriptorUpdate(
+    session: string,
+    sdp: string,
+    type: string,
+    candidates: Array<{ candidate: string; mid: string }>,
+  ): void
   onHeartbeat(session: string, ping: number): void
   onLanMessage(session: string, inf: LanServerInfo): void
+  onConnectionEstablished(session: string): void
 
   getNextIceServer(): RTCIceServer | undefined
   getCurrentIceServer(): RTCIceServer | undefined

--- a/packages/wrtc-multiplayer/lib/connection.ts
+++ b/packages/wrtc-multiplayer/lib/connection.ts
@@ -7,7 +7,11 @@ import { Readable, Writable, finished } from 'stream'
 import { PeerContext } from './PeerContext'
 import { ServerProxy } from './ServerProxy'
 import { MessageGetSharedManifestEntry, MessageShareManifestEntry } from './messages/download'
-import { MessageHeartbeatPing, MessageHeartbeatPingEntry, MessageHeartbeatPongEntry } from './messages/heartbeat'
+import {
+  MessageHeartbeatPing,
+  MessageHeartbeatPingEntry,
+  MessageHeartbeatPongEntry,
+} from './messages/heartbeat'
 import { MessageIdentity, MessageIdentityEntry } from './messages/identity'
 import { MessageLanEntry } from './messages/lan'
 import { MessageEntry, MessageHandler, MessageType } from './messages/message'
@@ -65,32 +69,41 @@ export class PeerSession {
     if (idel) {
       return idel
     }
-    const channel = new RTCDuplexChannel(this.connection.createDataChannel(`download-${this.#channelPool.length}`, {
-      ordered: true,
-      protocol: 'download',
-    }), this.createStream, this.connection.sctp?.maxMessageSize ?? 16 * 1024)
+    const channel = new RTCDuplexChannel(
+      this.connection.createDataChannel(`download-${this.#channelPool.length}`, {
+        ordered: true,
+        protocol: 'download',
+      }),
+      this.createStream,
+      this.connection.sctp?.maxMessageSize ?? 16 * 1024,
+    )
     this.#channelPool.push(channel)
     return channel
   }
 
-  #streamQueue = new WorkerQueue<{ file: string; destination: Writable }>(async ({ file, destination }) => {
-    return new Promise<any>((resolve) => {
-      const channel = this.#getOrCreateDownloadChannel()
-      finished(destination, resolve)
-      channel.download(file, destination)
-    })
-  }, 32, {
-    shouldRetry: () => false,
-    isEqual: () => false,
-  })
+  #streamQueue = new WorkerQueue<{ file: string; destination: Writable }>(
+    async ({ file, destination }) => {
+      return new Promise<any>((resolve) => {
+        const channel = this.#getOrCreateDownloadChannel()
+        finished(destination, resolve)
+        channel.download(file, destination)
+      })
+    },
+    32,
+    {
+      shouldRetry: () => false,
+      isEqual: () => false,
+    },
+  )
 
   constructor(
     /**
-    * The session id
-    */
+     * The session id
+     */
     readonly id: string,
     public connection: RTCPeerConnection,
-    readonly context: PeerContext) {
+    readonly context: PeerContext,
+  ) {
     this.#updateDescriptor = debounce(() => {
       const description = this.connection.localDescription!
       context.onDescriptorUpdate(this.id, description.sdp, description.type, this.#candidates)
@@ -141,7 +154,9 @@ export class PeerSession {
           socket.destroy()
           channel.close()
         }
-        socket.on('data', (buf) => channel.readyState === 'open' ? channel.send(buf as any) : buffers.push(buf))
+        socket.on('data', (buf) =>
+          channel.readyState === 'open' ? channel.send(buf as any) : buffers.push(buf),
+        )
         channel.addEventListener('message', ({ data }) => socket.write(Buffer.from(data)))
         socket.on('close', () => {
           console.log(`Socket ${label} closed and close game channel ${id}`)
@@ -160,7 +175,13 @@ export class PeerSession {
         console.log('Metadata channel created')
       } else if (channel.protocol === 'download') {
         console.log(`Receive peer file request: ${channel.label}`)
-        this.#channelPool.push(new RTCDuplexChannel(channel, this.createStream, this.connection.sctp?.maxMessageSize ?? 16 * 1024))
+        this.#channelPool.push(
+          new RTCDuplexChannel(
+            channel,
+            this.createStream,
+            this.connection.sctp?.maxMessageSize ?? 16 * 1024,
+          ),
+        )
       } else {
         // TODO: emit error for unknown protocol
       }
@@ -193,7 +214,7 @@ export class PeerSession {
       if (!man) {
         return 'NO_PERMISSION'
       }
-      const file = man.files.find(v => decodeURI(v.path) === filePath)
+      const file = man.files.find((v) => decodeURI(v.path) === filePath)
       if (!file) {
         return 'NO_PERMISSION'
       }
@@ -232,17 +253,19 @@ export class PeerSession {
   async initiate() {
     // host
     console.log('peer initialize')
-    this.setChannel(this.connection.createDataChannel(this.id, {
-      ordered: true,
-      protocol: 'metadata',
-    }))
+    this.setChannel(
+      this.connection.createDataChannel(this.id, {
+        ordered: true,
+        protocol: 'metadata',
+      }),
+    )
 
     const offer = await this.connection.createOffer({
       offerToReceiveAudio: false,
       offerToReceiveVideo: false,
     })
 
-    console.log(`Create offer ${(offer.sdp)}`)
+    console.log(`Create offer ${offer.sdp}`)
     await this.connection.setLocalDescription(offer)
 
     this.#updateDescriptor()
@@ -304,6 +327,7 @@ export class PeerSession {
       console.log(`Create metadata channel on ${channel.id}`)
       const info = this.context.getUserInfo()
       this.send(MessageIdentity, { ...info })
+      this.context.onConnectionEstablished(this.id)
     }
     channel.onerror = (e) => {
       console.error(new Error('Fail to create metadata channel', { cause: e }))
@@ -314,7 +338,9 @@ export class PeerSession {
     this.#channel = channel
   }
 
-  get isClosed() { return this.#isClosed }
+  get isClosed() {
+    return this.#isClosed
+  }
 
   close() {
     this.#isClosed = true
@@ -331,7 +357,11 @@ export class PeerSession {
   }
 
   send<T>(type: MessageType<T>, data: T) {
-    if (this.connection.connectionState !== 'connected' || !this.#channel || this.#channel.readyState !== 'open') {
+    if (
+      this.connection.connectionState !== 'connected' ||
+      !this.#channel ||
+      this.#channel.readyState !== 'open'
+    ) {
       return
     }
     this.#channel?.send(JSON.stringify({ type: type as string, payload: data }))

--- a/packages/wrtc-multiplayer/lib/iceServers.test.ts
+++ b/packages/wrtc-multiplayer/lib/iceServers.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { getIceServers } from './iceServers'
+
+describe('getIceServers', () => {
+  it('uses the authenticated built-in TURN credential provider', async () => {
+    const credential = vi.fn(async () => ({
+      stuns: ['stun.example:3478'],
+      uris: ['turn:20.239.69.131'],
+      username: 'user',
+      password: 'password',
+      ttl: 86_400,
+      meta: {
+        '20.239.69.131': 'hk',
+      },
+    }))
+
+    const result = await getIceServers(credential)
+
+    expect(credential).toHaveBeenCalledOnce()
+    expect(result).toEqual({
+      servers: [
+        {
+          urls: 'turn:20.239.69.131',
+          username: 'user',
+          credential: 'password',
+        },
+        {
+          urls: 'stun:stun.example:3478',
+        },
+      ],
+      meta: {
+        '20.239.69.131': 'hk',
+      },
+    })
+  })
+})

--- a/packages/wrtc-multiplayer/lib/iceServers.ts
+++ b/packages/wrtc-multiplayer/lib/iceServers.ts
@@ -1,3 +1,4 @@
+import type { MultiplayerIceServerCredential } from '@xmcl/runtime-api'
 import { readFile } from 'fs/promises'
 import { join } from 'path'
 import { PeerConnectionFactory } from './PeerConnectionFactory'
@@ -12,33 +13,19 @@ const BUILTIN = [
   'stun2.l.google.com:19302',
   'stun3.l.google.com:19302',
   'stun4.l.google.com:19302',
-].map(s => ({
+].map((s) => ({
   urls: `stun:${s}`,
 }))
 
-export async function getIceServers() {
+export async function getIceServers(getCredential: () => Promise<MultiplayerIceServerCredential>) {
   console.log('Try to fetch rtc credential')
-  const response = await fetch(
-    'https://api.xmcl.app/rtc/official',
-    {
-      method: 'POST',
-    })
-  if (response.status === 200) {
-    const credential: {
-      uris: string[]
-      ttl: number
-      password: string
-      username: string
-      stuns: string[]
-      meta: Record<string, string>
-    } | {
-      stuns: string[]
-    } = await response.json() as any
+  try {
+    const credential = await getCredential()
     const result: RTCIceServer[] = credential.stuns.map((s) => ({
       urls: `stun:${s}`,
     }))
 
-    if ('uris' in credential && credential.uris) {
+    if (credential.uris && credential.username && credential.password) {
       for (const uri of credential.uris) {
         result.unshift({
           urls: uri,
@@ -50,9 +37,9 @@ export async function getIceServers() {
 
     return {
       servers: result,
-      meta: 'meta' in credential ? credential.meta : undefined,
+      meta: credential.meta,
     }
-  } else {
+  } catch {
     return {
       servers: [],
     }
@@ -67,7 +54,7 @@ export async function loadIceServers(cachePath: string) {
     if (caches instanceof Array && caches.length > 0) {
       console.log('Load ice servers from cache', caches)
       return caches
-        .filter(v => typeof v === 'object')
+        .filter((v) => typeof v === 'object')
         .map((v: object) => {
           if ('hostname' in v) {
             const vv = v as any
@@ -137,33 +124,39 @@ async function testIceServers(
   portBegin?: number,
 ) {
   const ipSet = new Set<string>()
-  await Promise.all(servers.map(async (server) => {
-    if (typeof server.urls === 'object' ? server.urls.some(v => v.includes('cloudflare.com')) : server.urls.includes('cloudflare.com')) {
-      console.log('bypass cloudflare url', server)
-      const key = getKey(server)
-      delete blocked[key]
-      passed[key] = server
-      onValidIceServer(server, 0)
-      return
-    }
-    const [ips, ping] = await test(factory, server, portBegin).catch(() => [])
-    // console.log('Test ice server', server, ips)
-    const key = getKey(server)
-    if (ips.length > 0) {
-      passed[key] = server
-      delete blocked[key]
-      onValidIceServer(server, ping)
-      for (const ip of ips) {
-        if (!ipSet.has(ip)) {
-          ipSet.add(ip)
-          onIp(ip)
-        }
+  await Promise.all(
+    servers.map(async (server) => {
+      if (
+        typeof server.urls === 'object'
+          ? server.urls.some((v) => v.includes('cloudflare.com'))
+          : server.urls.includes('cloudflare.com')
+      ) {
+        console.log('bypass cloudflare url', server)
+        const key = getKey(server)
+        delete blocked[key]
+        passed[key] = server
+        onValidIceServer(server, 0)
+        return
       }
-    } else {
-      blocked[key] = server
-      delete passed[key]
-    }
-  }))
+      const [ips, ping] = await test(factory, server, portBegin).catch(() => [])
+      // console.log('Test ice server', server, ips)
+      const key = getKey(server)
+      if (ips.length > 0) {
+        passed[key] = server
+        delete blocked[key]
+        onValidIceServer(server, ping)
+        for (const ip of ips) {
+          if (!ipSet.has(ip)) {
+            ipSet.add(ip)
+            onIp(ip)
+          }
+        }
+      } else {
+        blocked[key] = server
+        delete passed[key]
+      }
+    }),
+  )
 }
 
 const isSameRTCServer = (a: RTCIceServer, b: RTCIceServer) => {
@@ -177,11 +170,12 @@ export function createIceServersProvider(
   onValidIceServer: (server: RTCIceServer, ping?: number | 'timeout') => void,
   onIp: (ip: string) => void,
   onMeta: (meta: Record<string, string>) => void,
+  getCredential: () => Promise<MultiplayerIceServerCredential>,
 ) {
   const passed: Record<string, RTCIceServer> = {}
   const blocked: Record<string, RTCIceServer> = {}
 
-  let _resolve = () => { }
+  let _resolve = () => {}
   const initPromise: Promise<void> = new Promise((resolve) => {
     _resolve = resolve
   })
@@ -192,7 +186,7 @@ export function createIceServersProvider(
     },
     async init(cachePath: string) {
       console.log('Init ice servers')
-      loadIceServers(cachePath).then(cached => {
+      loadIceServers(cachePath).then((cached) => {
         const all = [...cached, ...BUILTIN]
         const pending: Record<string, any> = {}
         for (const a of all) {
@@ -204,14 +198,15 @@ export function createIceServersProvider(
       }, _resolve)
     },
     async update() {
-      const { servers, meta } = await getIceServers()
+      const { servers, meta } = await getIceServers(getCredential)
       if (meta) {
         onMeta(meta)
       }
       testIceServers(factory, servers, passed, blocked, onValidIceServer, onIp)
     },
     get(preferredIceServers: RTCIceServer[] = []) {
-      const servers = Object.keys(passed).length > 0 ? Object.values(passed) : Object.values(blocked)
+      const servers =
+        Object.keys(passed).length > 0 ? Object.values(passed) : Object.values(blocked)
       // sort all servers by preferredIceServers
       if (preferredIceServers.length > 0) {
         servers.sort((a, b) => {
@@ -230,8 +225,16 @@ export function createIceServersProvider(
         })
       }
 
-      const turns = servers.filter((s) => typeof s.urls === 'string' ? s.urls.startsWith('turn') : s.urls.some((u) => u.startsWith('turn')))
-      const stuns = servers.filter((s) => typeof s.urls === 'string' ? s.urls.startsWith('stun') : s.urls.some((u) => u.startsWith('stun')))
+      const turns = servers.filter((s) =>
+        typeof s.urls === 'string'
+          ? s.urls.startsWith('turn')
+          : s.urls.some((u) => u.startsWith('turn')),
+      )
+      const stuns = servers.filter((s) =>
+        typeof s.urls === 'string'
+          ? s.urls.startsWith('stun')
+          : s.urls.some((u) => u.startsWith('stun')),
+      )
 
       return [stuns, turns]
     },

--- a/packages/wrtc-multiplayer/lib/multiplayerImpl.ts
+++ b/packages/wrtc-multiplayer/lib/multiplayerImpl.ts
@@ -1,4 +1,10 @@
-import { SharedState, PeerState, SetRemoteDescriptionOptions, TransferDescription, createPromiseSignal } from '@xmcl/runtime-api'
+import {
+  SharedState,
+  PeerState,
+  SetRemoteDescriptionOptions,
+  TransferDescription,
+  createPromiseSignal,
+} from '@xmcl/runtime-api'
 import { randomUUID } from 'crypto'
 import EventEmitter from 'events'
 import { promisify } from 'util'
@@ -12,7 +18,7 @@ import { createIceServersProvider, getKey } from './iceServers'
 import { createLanDiscover } from './lanDiscover'
 import { exposeLocalPort, parseCandidate } from './mapAndGetPortCanidate'
 import { raceNatType } from './nat'
-import { createPeerGroup } from './peerGorup'
+import { createPeerGroup, MultiplayerRoomApi } from './peerGorup'
 import { createPeerSharing } from './peerSharing'
 import { createPeerUserInfo } from './peerUserInfo'
 import { InitiateOptions, Peers } from './peers'
@@ -28,7 +34,7 @@ async function decode(description: string): Promise<TransferDescription> {
   return JSON.parse((await pBrotliDecompress(Buffer.from(description, 'base64'))).toString('utf-8'))
 }
 
-export function createMultiplayer() {
+export function createMultiplayer(roomApi: MultiplayerRoomApi) {
   const peers = new Peers()
   const state = createPromiseSignal<SharedState<PeerState>>()
   const emitter = new EventEmitter()
@@ -48,43 +54,63 @@ export function createMultiplayer() {
   const sharing = createPeerSharing(peers)
   const userInfo = createPeerUserInfo()
   const host = createHosting(peers)
-  const group = createPeerGroup(idSignal, peers, userInfo.getUserInfo, initiate, setRemoteDescription, (gstate) => {
-    state.then(s => s.groupStateSet(gstate))
-  }, (e) => {
-    state.then(s => {
-      if (e instanceof Error) {
-        s.groupErrorSet({
-          message: e.message,
-          name: e.name,
-          stack: e.stack,
-        })
-      }
-      console.warn(e)
-    })
-  }, (id) => {
-    state.then(s => s.groupSet({ group: id, state: 'connected' }))
-  }, () => {
-    state.then(s => s.groupSet({ group: '', state: 'closed' }))
-  }, (sender, profile) => {
-    state.then(s => {
-      const target = peers.get(sender)
-      if (target) {
-        s.connectionUserInfo({ id: target.id, info: profile })
-      }
-    })
-  }, (ping, timestamp) => {
-    state.then(s => s.pingSet({ ping, timestamp }))
-  })
+  const group = createPeerGroup(
+    idSignal,
+    peers,
+    userInfo.getUserInfo,
+    initiate,
+    setRemoteDescription,
+    roomApi,
+    (gstate) => {
+      state.then((s) => s.groupStateSet(gstate))
+    },
+    (e) => {
+      state.then((s) => {
+        if (e instanceof Error) {
+          s.groupErrorSet({
+            message: e.message,
+            name: e.name,
+            stack: e.stack,
+          })
+        }
+        console.warn(e)
+      })
+    },
+    (admission) => {
+      state.then((s) =>
+        s.groupSet({
+          group: admission.roomId,
+          state: 'connecting',
+          role: admission.role,
+          maxPeers: admission.maxPeers ?? 0,
+        }),
+      )
+    },
+    () => {
+      state.then((s) => s.groupSet({ group: '', state: 'closed', role: '', maxPeers: 0 }))
+    },
+    (sender, profile) => {
+      state.then((s) => {
+        const target = peers.get(sender)
+        if (target) {
+          s.connectionUserInfo({ id: target.id, info: profile })
+        }
+      })
+    },
+    (ping, timestamp) => {
+      state.then((s) => s.pingSet({ ping, timestamp }))
+    },
+  )
 
   state.then((s) => {
     s.subscribe('exposedPortsSet', (ports) => {
-      discover.setExposedPorts(ports.map(p => p[0]))
+      discover.setExposedPorts(ports.map((p) => p[0]))
     })
-    discover.setExposedPorts(s.exposedPorts.map(p => p[0]))
+    discover.setExposedPorts(s.exposedPorts.map((p) => p[0]))
   })
 
   peers.onremove = (id) => {
-    state.then(s => s.connectionDrop(id))
+    state.then((s) => s.connectionDrop(id))
   }
 
   const facotry: PeerConnectionFactory = {
@@ -99,14 +125,17 @@ export function createMultiplayer() {
       console.log('Use node data channel', server)
       try {
         if (_RTCPeerConnection && _PeerConnection) {
-          return new _RTCPeerConnection({
-            iceServers: server ? [server] : [],
-            iceTransportPolicy: 'all',
-            portRangeBegin: privatePort,
-            portRangeEnd: privatePort,
-            enableIceUdpMux: true,
-            // @ts-ignore
-          }, _PeerConnection)
+          return new _RTCPeerConnection(
+            {
+              iceServers: server ? [server] : [],
+              iceTransportPolicy: 'all',
+              portRangeBegin: privatePort,
+              portRangeEnd: privatePort,
+              enableIceUdpMux: true,
+            },
+            // @ts-expect-error node-datachannel polyfill accepts its native constructor here.
+            _PeerConnection,
+          )
         } else {
           return new RTCPeerConnection({
             iceServers: server ? [server] : [],
@@ -128,26 +157,33 @@ export function createMultiplayer() {
     facotry,
     (server, ping) => {
       console.log('Valid ice server', server)
-      state.then(s => s.validIceServerSet(Array.from(new Set([...s.validIceServers, getKey(server)]))))
+      state.then((s) =>
+        s.validIceServerSet(Array.from(new Set([...s.validIceServers, getKey(server)]))),
+      )
       if (ping) {
         const rawKey = getKey(server)
         const key = rawKey.split(':')[1] || rawKey
-        state.then(s => s.iceServerPingSet({ server: key, ping }))
+        state.then((s) => s.iceServerPingSet({ server: key, ping }))
       }
       debouncedRefreshNat()
     },
     (ip) => {
       console.log('Public ip', ip)
-      state.then(s => s.ipsSet(Array.from(new Set([...s.ips, ip]))))
+      state.then((s) => s.ipsSet(Array.from(new Set([...s.ips, ip]))))
     },
     (meta) => {
-      state.then(s => s.turnserversSet(meta))
+      state.then((s) => s.turnserversSet(meta))
     },
+    roomApi.getIceServerCredential,
   )
   const portCandidate = 35565
 
-  const createContext = (remoteId: string | undefined, targetIceServer: RTCIceServer | undefined, preferredIceServers: Array<RTCIceServer>): PeerContext => {
-    const isAllowTurn = () => localStorage.getItem('peerAllowTurn') === 'true'
+  const createContext = (
+    remoteId: string | undefined,
+    targetIceServer: RTCIceServer | undefined,
+    preferredIceServers: Array<RTCIceServer>,
+  ): PeerContext => {
+    const isAllowTurn = () => localStorage.getItem('peerAllowTurn') !== 'false'
     let stunIndex = 0
     let turnIndex = 0
     let current: RTCIceServer | undefined
@@ -170,7 +206,7 @@ export function createMultiplayer() {
         if (isAllowTurn() && turns.length > 0) {
           const preferredTurn = localStorage.getItem('peerPreferredTurn')
           if (preferredTurn) {
-            const index = turns.findIndex(s => s.urls.includes(preferredTurn))
+            const index = turns.findIndex((s) => s.urls.includes(preferredTurn))
             if (index !== -1) {
               const cur = turns[index]
               current = cur
@@ -195,10 +231,10 @@ export function createMultiplayer() {
         return cur
       },
       onHeartbeat: (session, ping) => {
-        state.then(s => s.connectionPing({ id: session, ping }))
+        state.then((s) => s.connectionPing({ id: session, ping }))
       },
       onInstanceShared: (session, manifest) => {
-        state.then(s => s.connectionShareManifest({ id: session, manifest }))
+        state.then((s) => s.connectionShareManifest({ id: session, manifest }))
       },
       onDescriptorUpdate: (session, sdp, type, candidates) => {
         console.log(candidates)
@@ -209,50 +245,46 @@ export function createMultiplayer() {
           console.log(`Send local description ${remoteId}: ${sdp} ${type}`)
           // Send to the group if the remoteId is set
           const [stuns] = iceServers.get(preferredIceServers)
-          if (current) {
-            group.getGroup()?.sendLocalDescription(remoteId, sdp, type, candidates, current, stuns, () => {
-              const sess = peers.get(session)
-              // not retry if the connection is established
-              if (sess && sess.isDataChannelEstablished()) return false
-              return true
-            }).then(v => {
-              if (!v) return
-              // remove this peer
-              const sess = peers.get(session)
-              if (sess) {
-                if (!sess.isDataChannelEstablished()) {
-                  peers.get(session)?.close()
-                  peers.remove(session)
-                  state.then(s => s.connectionDrop(session))
-                }
-              }
-            })
+          if (current && (type === 'offer' || type === 'answer')) {
+            group
+              .getGroup()
+              ?.sendLocalDescription(remoteId, sdp, type, candidates, current, stuns, () => true)
+              .catch(console.error)
           }
         }
 
-        const candidate = candidates.find(c => c.candidate.indexOf('typ srflx') !== -1)
+        const candidate = candidates.find((c) => c.candidate.indexOf('typ srflx') !== -1)
         if (candidate) {
           const [ip, port] = parseCandidate(candidate.candidate)
           if (ip && port) {
             exposeLocalPort(portCandidate, Number(port)).catch((e) => {
-              if (e.name === 'Error') { e.name = 'MapNatError' }
+              if (e.name === 'Error') {
+                e.name = 'MapNatError'
+              }
               console.error(e)
             })
           }
         }
 
-        pBrotliCompress(JSON.stringify(payload)).then((s) => s.toString('base64')).then((compressed) => {
-          state.then(s => s.connectionLocalDescription({ id: payload.session, description: compressed }))
-        })
+        pBrotliCompress(JSON.stringify(payload))
+          .then((s) => s.toString('base64'))
+          .then((compressed) => {
+            state.then((s) =>
+              s.connectionLocalDescription({ id: payload.session, description: compressed }),
+            )
+          })
       },
       onIdentity: (session, info) => {
         const p = peers.get(session)
         if (p) {
           p.remoteInfo = info
         }
-        state.then(s => s.connectionUserInfo({ id: session, info }))
+        state.then((s) => s.connectionUserInfo({ id: session, info }))
       },
       onLanMessage: discover.onLanMessage,
+      onConnectionEstablished: () => {
+        if (remoteId) group.getGroup()?.markConnected(remoteId)
+      },
       getUserInfo: userInfo.getUserInfo,
       getSharedInstance: sharing.getSharedInstance,
       getShadedInstancePath: sharing.getShadedInstancePath,
@@ -276,6 +308,7 @@ export function createMultiplayer() {
     const remoteId = options.remoteId
     const sessionId = options.session || randomUUID()
     const preferredIceServers = options.preferredIceServers || []
+    let roomReconnectAttempts = 0
 
     console.log(`Create peer connection to [${remoteId}]. Is initiator: ${initiator}`)
     const privatePort = portCandidate
@@ -284,42 +317,89 @@ export function createMultiplayer() {
       const ice = ctx.getNextIceServer()
 
       if (ice) {
-        state.then(s => s.connectionIceServersSet({ id: sessionId, iceServer: ice }))
+        state.then((s) => s.connectionIceServersSet({ id: sessionId, iceServer: ice }))
       }
 
       const co = facotry.createConnection(ice, privatePort)
 
       co.onsignalingstatechange = () => {
-        state.then(s => s.signalingStateChange({ id: sessionId, signalingState: co.signalingState }))
+        state.then((s) =>
+          s.signalingStateChange({ id: sessionId, signalingState: co.signalingState }),
+        )
       }
       co.onicegatheringstatechange = () => {
-        state.then(s => s.iceGatheringStateChange({ id: sessionId, iceGatheringState: co.iceGatheringState }))
+        state.then((s) =>
+          s.iceGatheringStateChange({ id: sessionId, iceGatheringState: co.iceGatheringState }),
+        )
       }
       co.onconnectionstatechange = () => {
-        // const pair = co.getSelectedCandidatePair()
-        // if (pair) {
-        //   console.log('Select pair %o', pair)
-        //   state?.connectionSelectedCandidate({
-        //     id: sessionId,
-        //     remote: pair.remote as any,
-        //     local: pair.local as any,
-        //   })
-        // }
-        state.then(s => s.connectionStateChange({ id: sessionId, connectionState: co.connectionState }))
-        if (co.connectionState === 'closed' || co.connectionState === 'disconnected' || co.connectionState === 'failed') {
+        const pair = (
+          co as RTCPeerConnection & {
+            getSelectedCandidatePair?: () => {
+              local: {
+                address: string
+                port: number
+                type: 'host' | 'prflx' | 'srflx' | 'relay'
+                protocol?: 'udp' | 'tcp'
+              }
+              remote: {
+                address: string
+                port: number
+                type: 'host' | 'prflx' | 'srflx' | 'relay'
+                protocol?: 'udp' | 'tcp'
+              }
+            }
+          }
+        ).getSelectedCandidatePair?.()
+        if (pair) {
+          state.then((s) =>
+            s.connectionSelectedCandidate({
+              id: sessionId,
+              local: { ...pair.local, transportType: pair.local.protocol ?? 'udp' },
+              remote: { ...pair.remote, transportType: pair.remote.protocol ?? 'udp' },
+            }),
+          )
+        }
+        state.then((s) =>
+          s.connectionStateChange({ id: sessionId, connectionState: co.connectionState }),
+        )
+        if (co.connectionState === 'connected' && remoteId) {
+          roomReconnectAttempts = 0
+          group.getGroup()?.markConnected(remoteId)
+        }
+        if (
+          co.connectionState === 'closed' ||
+          co.connectionState === 'disconnected' ||
+          co.connectionState === 'failed'
+        ) {
           if (sess.isClosed) {
             // Close by user manually
             peers.remove(sessionId)
-            state.then(s => s.connectionDrop(sessionId))
+            state.then((s) => s.connectionDrop(sessionId))
           } else {
-            if (initiator) {
+            const activeRoom = group.getGroup()
+            if (activeRoom) {
+              if (initiator && activeRoom.role === 'host' && roomReconnectAttempts < 6) {
+                roomReconnectAttempts++
+                const next = create(ctx, sessionId)
+                sess.setConnection(next)
+                sess.initiate()
+              } else {
+                if (remoteId && activeRoom.role === 'host') {
+                  activeRoom.removePeer(remoteId)
+                }
+                sess.close()
+                peers.remove(sessionId)
+                state.then((s) => s.connectionDrop(sessionId))
+              }
+            } else if (initiator) {
               // unexpected close! reconnect
               const s = create(ctx, sessionId)
               sess.setConnection(s)
               sess.initiate()
             } else {
               peers.remove(sessionId)
-              state.then(s => s.connectionDrop(sessionId))
+              state.then((s) => s.connectionDrop(sessionId))
             }
           }
         }
@@ -332,29 +412,31 @@ export function createMultiplayer() {
       group.getGroup()?.sendWho(remoteId)
     }
 
-    state.then(s => s.connectionAdd({
-      id: sessionId,
-      initiator,
-      remoteId: remoteId ?? '',
-      userInfo: {
-        name: '',
-        id: '',
-        textures: {
-          SKIN: { url: '' },
+    state.then((s) =>
+      s.connectionAdd({
+        id: sessionId,
+        initiator,
+        remoteId: remoteId ?? '',
+        userInfo: {
+          name: '',
+          id: '',
+          textures: {
+            SKIN: { url: '' },
+          },
+          avatar: '',
         },
-        avatar: '',
-      },
-      iceServer: { urls: [] },
-      triedIceServers: [],
-      preferredIceServers,
-      ping: -1,
-      signalingState: 'closed',
-      localDescriptionSDP: '',
-      iceGatheringState: 'new',
-      connectionState: 'new',
-      sharing: undefined,
-      selectedCandidate: undefined,
-    }))
+        iceServer: { urls: [] },
+        triedIceServers: [],
+        preferredIceServers,
+        ping: -1,
+        signalingState: 'closed',
+        localDescriptionSDP: '',
+        iceGatheringState: 'new',
+        connectionState: 'new',
+        sharing: undefined,
+        selectedCandidate: undefined,
+      }),
+    )
 
     const ctx = createContext(remoteId, options.targetIceServer, preferredIceServers)
     const sess = new PeerSession(sessionId, create(ctx, sessionId), ctx)
@@ -371,16 +453,37 @@ export function createMultiplayer() {
     return sess
   }
 
-  function setRemoteDescription({ sdp, candidates, id: sender, session }: TransferDescription, type: 'offer' | 'answer', targetIceServer?: RTCIceServer, preferredIceServers?: RTCIceServer[]) {
+  function setRemoteDescription(
+    { sdp, candidates, id: sender, session }: TransferDescription,
+    type: 'offer' | 'answer',
+    targetIceServer?: RTCIceServer,
+    preferredIceServers?: RTCIceServer[],
+  ) {
     let sess = peers.get(session, sender)
 
     const newPeer = !sess
     if (!sess) {
       console.log(`Not found the ${sender}. Initiate new connection`)
       // Try to connect to the sender
-      sess = initiate({ remoteId: sender, session, initiate: false, targetIceServer, preferredIceServers })
+      sess = initiate({
+        remoteId: sender,
+        session,
+        initiate: false,
+        targetIceServer,
+        preferredIceServers,
+      })
     } else if (targetIceServer) {
       sess.context.setTargetIceServer(targetIceServer)
+    }
+
+    const currentRemote = sess.connection.remoteDescription
+    if (currentRemote?.type === type && currentRemote.sdp === sdp) {
+      for (const { candidate, mid } of candidates) {
+        sess.connection.addIceCandidate({ candidate, sdpMid: mid }).catch(() => {
+          // Candidate updates can repeat while the local descriptor is debounced.
+        })
+      }
+      return sess.id
     }
 
     // const currentIceServer = sess.context.getCurrentIceServer()
@@ -393,7 +496,10 @@ export function createMultiplayer() {
     console.log(`Set remote ${type} description: ${sdp}`)
     console.log(candidates)
     const sState = sess.connection.signalingState
-    if ((sState === 'stable' || sState === 'have-local-offer') && !sess.isDataChannelEstablished()) {
+    if (
+      (sState === 'stable' || sState === 'have-local-offer') &&
+      !sess.isDataChannelEstablished()
+    ) {
       try {
         sess.setRemoteDescription({ sdp, type })
         for (const { candidate, mid } of candidates) {
@@ -419,12 +525,16 @@ export function createMultiplayer() {
       await Promise.all([
         s.natDeviceInfo
           ? Promise.resolve()
-          : getDeviceInfo().then((i) => {
-            if (i) { s.natDeviceSet(i) }
-          }).catch(e => {
-            console.error('Failed to get NAT device info:', e)
-          }),
-        raceNatType(s, (await iceServers.get())[0]).catch(e => {
+          : getDeviceInfo()
+              .then((i) => {
+                if (i) {
+                  s.natDeviceSet(i)
+                }
+              })
+              .catch((e) => {
+                console.error('Failed to get NAT device info:', e)
+              }),
+        raceNatType(s, (await iceServers.get())[0]).catch((e) => {
           console.error('Failed to race NAT type:', e)
         }),
       ])
@@ -462,8 +572,11 @@ export function createMultiplayer() {
     async drop(id: string): Promise<void> {
       const existed = peers.get(id)
       if (existed) {
+        if (existed.remoteId) {
+          group.getGroup()?.removePeer(existed.remoteId, true)
+        }
         existed.close()
-        state.then(s => s.connectionDrop(id))
+        state.then((s) => s.connectionDrop(id))
       }
     },
 

--- a/packages/wrtc-multiplayer/lib/peerGorup.test.ts
+++ b/packages/wrtc-multiplayer/lib/peerGorup.test.ts
@@ -1,0 +1,153 @@
+import type { ConnectionUserInfo, MultiplayerRoomAdmission } from '@xmcl/runtime-api'
+import { describe, expect, it, vi } from 'vitest'
+import type { Peers } from './peers'
+import { MultiplayerRoom, type MultiplayerRoomApi } from './peerGorup'
+
+class FakeSocket {
+  readyState = 0
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  sent: string[] = []
+
+  open() {
+    this.readyState = 1
+    this.onopen?.(new Event('open'))
+  }
+
+  receive(message: unknown) {
+    this.onmessage?.(
+      new MessageEvent('message', {
+        data: JSON.stringify(message),
+      }),
+    )
+  }
+
+  send(message: string) {
+    this.sent.push(message)
+  }
+
+  close(code = 1000, reason = '') {
+    this.readyState = 3
+    this.onclose?.({ code, reason } as CloseEvent)
+  }
+}
+
+const profile: ConnectionUserInfo = {
+  id: 'minecraft-profile',
+  name: 'Steve',
+  avatar: '',
+  textures: {
+    SKIN: { url: '' },
+  },
+}
+
+function admission(role: 'host' | 'guest'): MultiplayerRoomAdmission {
+  return {
+    roomId: 'room-1',
+    socketUrl: 'wss://api.example/v2/multiplayer/rooms/room-1/socket',
+    ticket: `${role}-ticket`,
+    peerId: `${role}-peer`,
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    role,
+  }
+}
+
+describe('MultiplayerRoom', () => {
+  it('lets the host initiate only toward an admitted guest', async () => {
+    const socket = new FakeSocket()
+    const initiate = vi.fn()
+    const room = new MultiplayerRoom(
+      admission('host'),
+      'local-id',
+      profile,
+      { get: vi.fn() } as unknown as Peers,
+      initiate,
+      vi.fn(),
+      {
+        createRoom: vi.fn(),
+        joinRoom: vi.fn(),
+        closeRoom: vi.fn(),
+        getIceServerCredential: vi.fn(),
+      },
+      () => socket,
+    )
+
+    const connecting = room.connect()
+    socket.open()
+    await connecting
+    socket.receive({
+      type: 'join-request',
+      guest: {
+        peerId: 'guest-peer',
+        accountId: 'guest-account',
+        displayName: 'Alex',
+      },
+      revision: 2,
+    })
+
+    expect(initiate).toHaveBeenCalledWith({
+      remoteId: 'guest-peer',
+      initiate: true,
+    })
+  })
+
+  it('closes guest signaling after rtc-ready without restoring it', async () => {
+    const socket = new FakeSocket()
+    const api: MultiplayerRoomApi = {
+      createRoom: vi.fn(),
+      joinRoom: vi.fn(),
+      closeRoom: vi.fn(),
+      getIceServerCredential: vi.fn(),
+    }
+    const peer = {
+      id: 'session',
+      isDataChannelEstablished: () => true,
+    }
+    const room = new MultiplayerRoom(
+      admission('guest'),
+      'local-id',
+      profile,
+      { get: vi.fn(() => peer) } as unknown as Peers,
+      vi.fn(),
+      vi.fn(),
+      api,
+      () => socket,
+    )
+
+    const connecting = room.connect()
+    socket.open()
+    await connecting
+    room.markConnected('host-peer')
+    expect(JSON.parse(socket.sent[0])).toEqual({ type: 'rtc-ready' })
+    socket.receive({ type: 'rtc-ready', revision: 3 })
+    socket.close(1000, 'Signaling complete')
+
+    expect(api.joinRoom).not.toHaveBeenCalled()
+  })
+
+  it('rejects a signaling socket that closes before the upgrade opens', async () => {
+    const socket = new FakeSocket()
+    const room = new MultiplayerRoom(
+      admission('guest'),
+      'local-id',
+      profile,
+      { get: vi.fn() } as unknown as Peers,
+      vi.fn(),
+      vi.fn(),
+      {
+        createRoom: vi.fn(),
+        joinRoom: vi.fn(),
+        closeRoom: vi.fn(),
+        getIceServerCredential: vi.fn(),
+      },
+      () => socket,
+    )
+
+    const connecting = room.connect()
+    socket.close(401, 'Unauthorized')
+
+    await expect(connecting).rejects.toThrow('multiplayer_room_websocket_closed_before_open:401')
+  })
+})

--- a/packages/wrtc-multiplayer/lib/peerGorup.ts
+++ b/packages/wrtc-multiplayer/lib/peerGorup.ts
@@ -1,9 +1,8 @@
-import { ConnectionUserInfo, GameProfileAndTexture, PromiseSignal, createPromiseSignal } from '@xmcl/runtime-api'
-import { setTimeout } from 'timers/promises'
-import { PeerSession } from './connection'
+import { ConnectionUserInfo, PromiseSignal } from '@xmcl/runtime-api'
+import type { MultiplayerIceServerCredential, MultiplayerRoomAdmission } from '@xmcl/runtime-api'
 import type { InitiateOptions, Peers } from './peers'
 
-type DescriptionType = string
+type DescriptionType = 'offer' | 'answer'
 
 export interface TransferDescription {
   session: string
@@ -12,37 +11,47 @@ export interface TransferDescription {
   candidates: Array<{ candidate: string; mid: string }>
 }
 
-type RelayPeerMessage = {
-  type: 'DESCRIPTOR-ECHO'
-  receiver: string
-  sender: string
-  id: number
-} | {
-  type: 'DESCRIPTOR'
-  receiver: string
-  sender: string
+interface SignalDescription {
   sdp: string
-  candidates: Array<{ candidate: string; mid: string }>
   sdpType: DescriptionType
-  id: number
+  session: string
+  candidates: Array<{ candidate: string; mid: string }>
   iceServer?: RTCIceServer
   iceServers?: RTCIceServer[]
-} | {
-  type: 'WHO'
-  receiver: string
-  sender: string
-} | {
-  type: 'ME'
-  sender: string
-  profile: ConnectionUserInfo
-} | {
-  type: 'PONG'
-  timestamp: number
 }
 
-function convertUUIDToUint8Array(id: string) {
-  const ints = id.replace(/-/g, '').match(/.{2}/g)!.map((v) => parseInt(v, 16))
-  return new Uint8Array(ints)
+interface RoomPeer {
+  peerId: string
+  accountId: string
+  displayName: string
+  status?: 'negotiating' | 'connected'
+}
+
+type RoomServerMessage =
+  | { type: 'host-ready'; self: RoomPeer; guests: RoomPeer[]; revision: number }
+  | { type: 'negotiation-started'; self: RoomPeer; hostPeerId: string; revision: number }
+  | { type: 'join-request'; guest: RoomPeer; revision: number }
+  | { type: 'signal'; sender: string; payload: SignalDescription }
+  | { type: 'guest-connected'; guest: RoomPeer; revision: number }
+  | { type: 'guest-negotiation-ended'; peerId: string; revision: number }
+  | { type: 'rtc-ready'; revision: number }
+  | { type: 'error'; code: string }
+
+export interface MultiplayerRoomApi {
+  createRoom(displayName: string, maxPeers?: number): Promise<MultiplayerRoomAdmission>
+  joinRoom(roomId: string, displayName: string): Promise<MultiplayerRoomAdmission>
+  closeRoom(roomId: string): Promise<void>
+  getIceServerCredential(): Promise<MultiplayerIceServerCredential>
+}
+
+interface RoomSocket {
+  readyState: number
+  onopen: ((event: Event) => void) | null
+  onmessage: ((event: MessageEvent) => void) | null
+  onerror: ((event: Event) => void) | null
+  onclose: ((event: CloseEvent) => void) | null
+  send(message: string): void
+  close(code?: number, reason?: string): void
 }
 
 export function createPeerGroup(
@@ -50,297 +59,288 @@ export function createPeerGroup(
   peers: Peers,
   getUserInfo: () => ConnectionUserInfo,
   initiate: (option: InitiateOptions) => void,
-  setRemoteDescription: (d: TransferDescription, type: 'offer' | 'answer', t?: RTCIceServer, all?: RTCIceServer[]) => string,
-  onstate = (state: 'connecting' | 'connected' | 'closing' | 'closed') => { },
-  onerror = (e: unknown) => { },
-  onjoin = (groupId: string) => { },
-  onleave = () => { },
-  onuser = (sender: string, profile: ConnectionUserInfo) => { },
-  onping = (ping: number, timestamp: number) => { },
+  setRemoteDescription: (
+    d: TransferDescription,
+    type: 'offer' | 'answer',
+    target?: RTCIceServer,
+    all?: RTCIceServer[],
+  ) => string,
+  roomApi: MultiplayerRoomApi,
+  onstate = (state: 'connecting' | 'connected' | 'closing' | 'closed') => {},
+  onerror = (_error: unknown) => {},
+  onjoin = (_admission: MultiplayerRoomAdmission) => {},
+  onleave = () => {},
+  onuser = (_sender: string, _profile: ConnectionUserInfo) => {},
+  onping = (_ping: number, _timestamp: number) => {},
 ) {
-  let _group: PeerGroup | undefined
+  let room: MultiplayerRoom | undefined
 
-  const cached = localStorage.getItem('peerGroup')
-  if (cached && typeof cached === 'string') {
-    console.log('Cached group', cached)
-    joinGroup(cached)
+  async function joinGroup(roomId?: string) {
+    try {
+      await room?.quit()
+      onstate('connecting')
+      const localId = await idSignal.promise
+      const profile = getUserInfo()
+      const admission = roomId
+        ? await roomApi.joinRoom(roomId, profile.name)
+        : await roomApi.createRoom(profile.name, 8)
+      room = new MultiplayerRoom(
+        admission,
+        localId,
+        profile,
+        peers,
+        initiate,
+        setRemoteDescription,
+        roomApi,
+      )
+      room.onstate = onstate
+      room.onerror = onerror
+      room.onuser = onuser
+      room.onping = onping
+      await room.connect()
+      onjoin(admission)
+    } catch (error) {
+      room = undefined
+      onerror(error)
+      onstate('closed')
+    }
   }
 
-  async function joinGroup(groupId?: string) {
-    console.log('Join group', groupId)
-    const _id = await idSignal.promise
-    if (!groupId) {
-      const buf = new Uint16Array(1)
-      window.crypto.getRandomValues(buf)
-      groupId = (getUserInfo()?.name ?? '') + '@' + buf[0]
-    }
-    localStorage.setItem('peerGroup', groupId)
-    _group = new PeerGroup(groupId, _id, () => getUserInfo())
-
-    _group.onheartbeat = (sender) => {
-      console.log(`Get heartbeat from ${sender}`)
-      const peer = peers.get(sender)
-      // Ask sender to connect to me :)
-      if (!peer) {
-        if (_id.localeCompare(sender) > 0) {
-          console.log(`Not found the ${sender} during heartbeat. Initiate new connection`)
-          // Only if my id is greater than other's id, we try to initiate the connection.
-          // This will have a total order in the UUID random space
-
-          // Try to connect to the sender
-          initiate({ remoteId: sender, initiate: true })
-        } else {
-          initiate({ remoteId: sender, initiate: false })
-        }
-      }
-    }
-    _group.ondescriptor = async (sender, sdp, type, candidates, iceServer, allIceServers) => {
-      setRemoteDescription({
-        id: sender,
-        session: '',
-        sdp,
-        candidates,
-      }, type as any, iceServer, allIceServers)
-    }
-    _group.onuser = onuser
-    _group.onstate = onstate
-    _group.onerror = onerror
-    _group.onwebsocketping = onping
-
-    onstate(_group.state)
-    onjoin(groupId)
-  }
-  function leaveGroup() {
-    _group?.quit()
-    _group = undefined
-    localStorage.setItem('peerGroup', '')
+  async function leaveGroup() {
+    const current = room
+    room = undefined
+    if (current) await current.quit()
     onleave()
   }
 
   return {
-    getGroup: () => _group,
+    getGroup: () => room,
     joinGroup,
     leaveGroup,
   }
 }
 
-export class PeerGroup {
-  private messageId = 0
-  private socket: WebSocket
-  public state: 'connecting' | 'connected' | 'closing' | 'closed'
+export class MultiplayerRoom {
+  private socket: RoomSocket | undefined
+  private closed = false
+  private signalingComplete = false
+  private reconnecting = false
 
-  readonly signals: Record<number, PromiseSignal<void>> = {}
+  onstate = (_state: 'connecting' | 'connected' | 'closing' | 'closed') => {}
+  onerror = (_error: unknown) => {}
+  onuser = (_sender: string, _profile: ConnectionUserInfo) => {}
+  onping = (_ping: number, _timestamp: number) => {}
 
-  #closed = false
-  #messageQueue: RelayPeerMessage[] = []
-  #id = ''
-  #heartbeat: ReturnType<typeof setInterval> | undefined
-  #url = ''
-  #heartbeatLastSeen: Record<string, number> = {}
+  constructor(
+    private admission: MultiplayerRoomAdmission,
+    readonly localId: string,
+    readonly profile: ConnectionUserInfo,
+    private readonly peers: Peers,
+    private readonly initiatePeer: (option: InitiateOptions) => void,
+    private readonly applyRemoteDescription: (
+      d: TransferDescription,
+      type: 'offer' | 'answer',
+      target?: RTCIceServer,
+      all?: RTCIceServer[],
+    ) => string,
+    private readonly roomApi: MultiplayerRoomApi,
+    private readonly createSocket: (url: string) => RoomSocket = (url) => new WebSocket(url),
+  ) {}
 
-  onstate = (state: 'connecting' | 'connected' | 'closing' | 'closed') => { }
-  onheartbeat = (sender: string) => { }
-  ondescriptor = (sender: string, sdp: string, type: DescriptionType, candidates: Array<{ candidate: string; mid: string }>, iceServer?: RTCIceServer, allServers?: RTCIceServer[]) => { }
-  onerror: (error: unknown) => void = () => { }
-  onuser = (sender: string, profile: ConnectionUserInfo) => { }
-  onwebsocketping = (ping: number, timestamp: number) => { }
-
-  constructor(readonly groupId: string, id: string, readonly gameProfile: () => GameProfileAndTexture) {
-    this.#id = id
-    this.#url = `wss://api.xmcl.app/group/${groupId}?client=${id}`
-    this.socket = new WebSocket(this.#url)
-    this.state = 'connecting'
-    const idBinary = convertUUIDToUint8Array(id)
-    const heartbeatMessage = new Uint8Array(16 + 8)
-    heartbeatMessage.set(idBinary)
-    const heartbeatView = new DataView(heartbeatMessage.buffer)
-    this.#heartbeat = setInterval(() => {
-      if (this.socket.readyState === this.socket.OPEN) {
-        heartbeatView.setFloat64(16, Date.now())
-        this.socket.send(heartbeatMessage)
-      }
-    }, 4_000)
-    this.#initiate()
+  get roomId() {
+    return this.admission.roomId
   }
 
-  #initiate() {
-    const { groupId, socket } = this
-    const id = this.#id
+  get role() {
+    return this.admission.role
+  }
 
-    socket.onopen = () => {
-      this.state = 'connected'
-      this.onstate?.(this.state)
-      for (let i = this.#messageQueue.shift(); i; i = this.#messageQueue.shift()) {
-        this.send(i)
+  async connect() {
+    if (this.closed) return
+    this.onstate('connecting')
+    const url = new URL(this.admission.socketUrl)
+    url.searchParams.set('ticket', this.admission.ticket)
+    const socket = this.createSocket(url.toString())
+    this.socket = socket
+    await new Promise<void>((resolve, reject) => {
+      let opened = false
+      let settled = false
+      socket.onopen = () => {
+        opened = true
+        settled = true
+        resolve()
       }
-    }
-    // socket.onping = heartbeat)
-    socket.onmessage = (event) => {
-      const { data } = event
-      const onHeartbeat = (data: Uint8Array) => {
-        const id = [...data]
-          .map((b) => ('00' + b.toString(16)).slice(-2))
-          .join('')
-          .replace(/(.{8})(.{4})(.{4})(.{4})(.{12})/, '$1-$2-$3-$4-$5')
-        if (id !== this.#id) {
-          this.onheartbeat?.(id)
-          this.#heartbeatLastSeen[id] = Date.now()
+      socket.onmessage = (event) => {
+        if (typeof event.data !== 'string') return
+        this.handle(JSON.parse(event.data) as RoomServerMessage)
+      }
+      socket.onerror = (event) => {
+        if (!opened && !settled) {
+          settled = true
+          reject(new Error('multiplayer_room_websocket_upgrade_failed', { cause: event }))
+        } else {
+          this.reportError(event)
         }
       }
-      if (data instanceof Blob) {
-        // Blob to Uint8Array
-        data.arrayBuffer().then(data => new Uint8Array(data))
-          .then(onHeartbeat)
-        return
-      }
-      if (data instanceof ArrayBuffer) {
-        onHeartbeat(new Uint8Array(data))
-        return
-      }
-      if (data instanceof Uint8Array) {
-        onHeartbeat(data)
-        return
-      }
-      if (typeof data === 'string') {
-        try {
-          const payload = JSON.parse(data.toString()) as RelayPeerMessage
-          if ('receiver' in payload && payload.receiver !== id) {
-            return
+      socket.onclose = (event) => {
+        if (socket !== this.socket || this.closed) return
+        this.socket = undefined
+        if (!opened) {
+          if (!settled) {
+            settled = true
+            reject(new Error(`multiplayer_room_websocket_closed_before_open:${event.code}`))
           }
-          if ('sender' in payload && payload.sender === id) {
-            return
-          }
-          if (payload.type === 'DESCRIPTOR') {
-            this.send({
-              type: 'DESCRIPTOR-ECHO',
-              receiver: payload.sender,
-              sender: id,
-              id: payload.id,
-            })
-            this.ondescriptor?.(payload.sender, payload.sdp, payload.sdpType, payload.candidates, payload.iceServer, payload.iceServers)
-          } else if (payload.type === 'DESCRIPTOR-ECHO') {
-            const signal = this.signals[payload.id]
-            if (signal) {
-              signal.resolve()
-              delete this.signals[payload.id]
-            }
-          } else if (payload.type === 'WHO') {
-            // Send who am I
-            const profile = this.gameProfile()
-            this.send({
-              type: 'ME',
-              sender: id,
-              profile: {
-                ...profile,
-                avatar: profile.textures.SKIN.url,
-              },
-            })
-          } else if (payload.type === 'ME') {
-            this.onuser?.(payload.sender, payload.profile)
-          } else if (payload.type === 'PONG') {
-            const now = Date.now()
-            const ping = (now - payload.timestamp) / 2
-            this.onwebsocketping?.(ping, payload.timestamp)
-          }
-        } catch (e) {
-          this.onerror?.(e)
-        }
-      }
-    }
-    const handleClosed = () => {
-      if (!this.#closed) {
-        // Try to reconnect as this is closed unexpected
-        this.state = 'connecting'
-        this.onstate?.(this.state)
-        const state = this.socket.readyState
-        const sock = this.socket
-        setTimeout(1000).then(() => {
-          if (sock === this.socket && state === this.socket.readyState) {
-            this.socket = new WebSocket(this.#url)
-            this.#initiate()
-          }
-        })
-      } else {
-        this.state = 'closed'
-        this.onstate?.(this.state)
-      }
-    }
-    socket.onerror = (e) => {
-      this.onerror?.(e)
-      handleClosed()
-    }
-    socket.onclose = (e) => {
-      const { wasClean, reason, code } = e
-      handleClosed()
-    }
-  }
-
-  wait(messageId: number): Promise<void> {
-    this.signals[messageId] = createPromiseSignal()
-    return this.signals[messageId].promise
-  }
-
-  async sendLocalDescription(receiverId: string, sdp: string, type: DescriptionType, candidates: Array<{ candidate: string; mid: string }>, iceServer: RTCIceServer, iceServers: RTCIceServer[], shouldRetry: () => boolean) {
-    const messageId = this.messageId++
-    const resolve = this.wait(messageId).then(() => true, () => false)
-    for (let i = 0; i < 60; ++i) {
-      try {
-        if (this.#closed) {
           return
         }
-        if ((Date.now() - this.#heartbeatLastSeen[receiverId]) > (5 * 60_000)) {
-          // If the receiver is not seen in 5 minutes, we stop sending
-          return 'NO_RESPONSE'
-        }
-        this.send({
-          type: 'DESCRIPTOR',
-          receiver: receiverId,
-          sdp,
-          sdpType: type,
-          sender: this.#id,
-          candidates,
-          id: messageId,
-          iceServer,
-          iceServers,
-        })
-        const responsed = await Promise.race([
-          resolve,
-          setTimeout(4_000).then(() => false), // wait 4 seconds for response
-        ])
-        if (responsed) {
+        if (this.role === 'guest' && this.signalingComplete && event.code === 1000) {
+          this.onstate('connected')
           return
         }
-        if (!shouldRetry()) {
-          return
-        }
-      } catch (e) {
-        this.onerror?.(e)
+        this.restore().catch((error) => this.fail(error))
       }
-    }
-    return 'NO_RESPONSE_TIMEOUT'
-  }
-
-  async sendWho(receiverId: string) {
-    this.send({
-      type: 'WHO',
-      receiver: receiverId,
-      sender: this.#id,
     })
   }
 
-  send(message: RelayPeerMessage) {
-    if (this.socket.readyState === this.socket.OPEN) {
-      this.socket.send(JSON.stringify(message))
-    } else {
-      this.#messageQueue.push(message)
+  async sendLocalDescription(
+    receiverId: string,
+    sdp: string,
+    type: DescriptionType,
+    candidates: Array<{ candidate: string; mid: string }>,
+    iceServer: RTCIceServer,
+    iceServers: RTCIceServer[],
+    _shouldRetry: () => boolean,
+  ) {
+    this.send({
+      type: 'signal',
+      receiver: receiverId,
+      payload: {
+        sdp,
+        sdpType: type,
+        session: this.peers.get(receiverId)?.id ?? '',
+        candidates,
+        iceServer,
+        iceServers,
+      },
+    })
+  }
+
+  sendWho(_receiverId: string) {
+    // Identity is exchanged over the authenticated metadata DataChannel.
+  }
+
+  markConnected(remoteId: string) {
+    if (this.role !== 'guest') return
+    const peer = this.peers.get(remoteId)
+    if (!peer || !peer.isDataChannelEstablished()) return
+    this.signalingComplete = true
+    this.send({ type: 'rtc-ready' })
+  }
+
+  removePeer(remoteId: string, kick = false) {
+    if (this.role !== 'host') return
+    this.send({ type: kick ? 'kick' : 'guest-left', peerId: remoteId })
+  }
+
+  private handle(message: RoomServerMessage) {
+    if (message.type === 'host-ready') {
+      this.onstate('connected')
+      for (const guest of message.guests) {
+        if (!this.peers.get(guest.peerId) && guest.status !== 'connected') {
+          this.initiatePeer({ remoteId: guest.peerId, initiate: true })
+        }
+      }
+      return
+    }
+    if (message.type === 'negotiation-started') {
+      return
+    }
+    if (message.type === 'join-request') {
+      if (this.role === 'host' && !this.peers.get(message.guest.peerId)) {
+        this.initiatePeer({ remoteId: message.guest.peerId, initiate: true })
+      }
+      return
+    }
+    if (message.type === 'signal') {
+      const payload = message.payload
+      this.applyRemoteDescription(
+        {
+          id: message.sender,
+          session: payload.session,
+          sdp: payload.sdp,
+          candidates: payload.candidates,
+        },
+        payload.sdpType,
+        payload.iceServer,
+        payload.iceServers,
+      )
+      return
+    }
+    if (message.type === 'guest-negotiation-ended') {
+      const peer = this.peers.get(message.peerId)
+      peer?.close()
+      this.peers.remove(message.peerId)
+      return
+    }
+    if (message.type === 'rtc-ready') {
+      this.signalingComplete = true
+      this.onstate('connected')
+      return
+    }
+    if (message.type === 'error') {
+      this.reportError(new Error(`multiplayer_room_${message.code}`))
     }
   }
 
-  quit() {
-    this.#closed = true
-    this.socket.close()
-    this.state = 'closing'
-    clearInterval(this.#heartbeat)
-    this.onstate?.(this.state)
+  private send(message: unknown) {
+    if (this.socket?.readyState !== 1) {
+      throw new Error('multiplayer_room_socket_unavailable')
+    }
+    this.socket.send(JSON.stringify(message))
+  }
+
+  private async restore() {
+    if (this.closed || this.reconnecting) return
+    this.reconnecting = true
+    this.onstate('connecting')
+    try {
+      const delays = [0, 500, 1_000, 2_000, 4_000]
+      let lastError: unknown
+      for (const delay of delays) {
+        if (this.closed) return
+        if (delay) await new Promise((resolve) => setTimeout(resolve, delay))
+        try {
+          const restored = await this.roomApi.joinRoom(this.roomId, this.profile.name)
+          this.admission = { ...restored, role: this.role }
+          await this.connect()
+          return
+        } catch (error) {
+          lastError = error
+        }
+      }
+      throw lastError ?? new Error('multiplayer_room_restore_failed')
+    } finally {
+      this.reconnecting = false
+    }
+  }
+
+  private fail(error: unknown) {
+    this.reportError(error)
+    this.onstate('closed')
+  }
+
+  private reportError(error: unknown) {
+    this.onerror(error)
+  }
+
+  async quit() {
+    if (this.closed) return
+    this.closed = true
+    this.onstate('closing')
+    if (this.role === 'host') {
+      await this.roomApi.closeRoom(this.roomId).catch((error) => this.reportError(error))
+    }
+    this.socket?.close(1000, 'Client left')
+    this.socket = undefined
+    this.onstate('closed')
   }
 }

--- a/xmcl-electron-app/preload/multiplayer.ts
+++ b/xmcl-electron-app/preload/multiplayer.ts
@@ -5,11 +5,13 @@ import './controller'
 import { serviceChannels } from './service'
 
 let inited = false
-ipcRenderer.invoke('multiplayer-init').then((payload: { appDataPath: string; resourcePath: string; sessionId: string }) => {
-  init(payload.appDataPath, payload.resourcePath, payload.sessionId)
-  emitter.emit('ready')
-  inited = true
-})
+ipcRenderer
+  .invoke('multiplayer-init')
+  .then((payload: { appDataPath: string; resourcePath: string; sessionId: string }) => {
+    init(payload.appDataPath, payload.resourcePath, payload.sessionId)
+    emitter.emit('ready')
+    inited = true
+  })
 
 ipcRenderer.on('peer-instance-shared', (_, options) => {
   shareInstance(options)
@@ -17,38 +19,52 @@ ipcRenderer.on('peer-instance-shared', (_, options) => {
 
 let stateReady = false
 const peerServ = serviceChannels.open(PeerServiceKey)
-peerServ.call('getPeerState').then((state) => state).then(state => {
-  for (const key of Object.getOwnPropertyNames(PeerState.prototype)) {
-    if (key === 'constructor' || (state as any)[key]) continue
-    if (typeof (PeerState.prototype as any)[key] === 'function') {
-      (state as any)[key] = (...args: any[]) => (state as any).commit(key, ...args)
+peerServ
+  .call('getPeerState')
+  .then((state) => state)
+  .then((state) => {
+    for (const key of Object.getOwnPropertyNames(PeerState.prototype)) {
+      if (key === 'constructor' || (state as any)[key]) continue
+      if (typeof (PeerState.prototype as any)[key] === 'function') {
+        ;(state as any)[key] = (...args: any[]) => (state as any).commit(key, ...args)
+      }
     }
-  }
-  state.subscribeAll((mutation, payload) => {
-    ((PeerState.prototype as any)[mutation] as Function | undefined)?.call(state, payload)
+    state.subscribeAll((mutation, payload) => {
+      ;((PeerState.prototype as any)[mutation] as Function | undefined)?.call(state, payload)
+    })
+    setState(state)
+    stateReady = true
   })
-  setState(state)
-  stateReady = true
-})
 
 const userServ = serviceChannels.open(UserServiceKey)
-userServ.call('getUserState').then((state) => state).then(state => {
-  let updated = false
-  if (Object.values(state.users).some(u => u.authority === AUTHORITY_MICROSOFT)) {
-    updateIceServers()
-    updated = true
-  }
-  if (!updated) {
-    state.subscribe('userProfile', (p) => {
-      if (p.authority === AUTHORITY_MICROSOFT) {
-        updateIceServers()
-        updated = true
-      }
-    })
-  }
-})
+userServ
+  .call('getUserState')
+  .then((state) => state)
+  .then((state) => {
+    let updated = false
+    if (Object.values(state.users).some((u) => u.authority === AUTHORITY_MICROSOFT)) {
+      updateIceServers()
+      updated = true
+    }
+    if (!updated) {
+      state.subscribe('userProfile', (p) => {
+        if (p.authority === AUTHORITY_MICROSOFT) {
+          updateIceServers()
+          updated = true
+        }
+      })
+    }
+  })
 
-const { init, emitter, shareInstance, setState, host, updateIceServers, ...peer } = createMultiplayer()
+const { init, emitter, shareInstance, setState, host, updateIceServers, ...peer } =
+  createMultiplayer({
+    createRoom: (displayName, maxPeers) =>
+      ipcRenderer.invoke('multiplayer-room-create', { displayName, maxPeers }),
+    joinRoom: (roomId, displayName) =>
+      ipcRenderer.invoke('multiplayer-room-join', { roomId, displayName }),
+    closeRoom: (roomId) => ipcRenderer.invoke('multiplayer-room-close', roomId),
+    getIceServerCredential: () => ipcRenderer.invoke('multiplayer-ice-servers'),
+  })
 
 listen(host, 25566, (p) => p + 2).then((s) => {
   ipcRenderer.invoke('multiplayer-port', s)
@@ -59,11 +75,16 @@ const multiplayer = {
   refreshNat: peer.refreshNat,
   isNatSupported: peer.isNatSupported,
   isReady: () => inited && stateReady,
-  on: (eventName: string | symbol, listener: (...args: any[]) => void) => emitter.on(eventName, listener),
-  once: (eventName: string | symbol, listener: (...args: any[]) => void) => emitter.once(eventName, listener),
-  off: (eventName: string | symbol, listener: (...args: any[]) => void) => emitter.off(eventName, listener),
-  addListener: (eventName: string | symbol, listener: (...args: any[]) => void) => emitter.addListener(eventName, listener),
-  removeListener: (eventName: string | symbol, listener: (...args: any[]) => void) => emitter.removeListener(eventName, listener),
+  on: (eventName: string | symbol, listener: (...args: any[]) => void) =>
+    emitter.on(eventName, listener),
+  once: (eventName: string | symbol, listener: (...args: any[]) => void) =>
+    emitter.once(eventName, listener),
+  off: (eventName: string | symbol, listener: (...args: any[]) => void) =>
+    emitter.off(eventName, listener),
+  addListener: (eventName: string | symbol, listener: (...args: any[]) => void) =>
+    emitter.addListener(eventName, listener),
+  removeListener: (eventName: string | symbol, listener: (...args: any[]) => void) =>
+    emitter.removeListener(eventName, listener),
 }
 
 contextBridge.exposeInMainWorld('multiplayer', multiplayer)

--- a/xmcl-keystone-ui/locales/en.yaml
+++ b/xmcl-keystone-ui/locales/en.yaml
@@ -1241,10 +1241,12 @@ multiplayer:
   connectionFailedHint: >-
     Unable to establish connection. Check if both peers have compatible NAT
     types.
+  connectedToHost: Connected to the room host
   connections: Connections
   copied: Copied!
   copy: Copy
   copyGroupToFriendHint: Let your friends join the group with this id
+  directConnection: Direct
   copyLocalHint: >
     "Please copy the local SDP text and send it to your object to have your
     object enter this text in the join connection <span>A token can be only used
@@ -1279,6 +1281,8 @@ multiplayer:
     until the ICE status is complete. If the token below remains unchanged, you
     can copy it and send it to your peer."
   groupId: Group Id
+  guest: Guest
+  host: Host
   illegalTokenDescription: Illegal token, please make sure the token from your peer is correct
   initiateConnection: Initiate Connection
   joinConnection: >-
@@ -1308,6 +1312,7 @@ multiplayer:
     automatically. Now you can close the dialog.
   receiveRemoteTokenHint: Please enter the token from your peer here.
   remoteToken: Remote Token
+  relayConnection: Relay
   routerInfo: Router Info
   sendTokenToRemote: Send Token to Remote
   share: Share Instance Config

--- a/xmcl-keystone-ui/locales/zh-CN.yaml
+++ b/xmcl-keystone-ui/locales/zh-CN.yaml
@@ -1044,11 +1044,13 @@ multiplayer:
   confirm: 确定
   connectionError: 连接错误
   connectionFailedHint: 无法建立连接。请检查双方的 NAT 类型是否兼容。
+  connectedToHost: 已连接到房主
   natWarning: 您的 NAT 类型可能阻碍直连。请尝试在设置中启用中继服务器，或让朋友作为主机。
   connections: 用户连接管理
   copied: 已复制！
   copy: 复制
   copyGroupToFriendHint: 让您的小伙伴使用此 ID 加入联机群组
+  directConnection: 直连
   copyLocalHint: >
     <span>一段令牌只能用<span style="color: red; font-weight:bold;">一次</span>！您不能将一个令牌发送给多个小伙伴！</span> <br> <span class="hint-text" style="font-style: italic;">如果有多个小伙伴要加入您需要<span style="font-weight: bold; color: rgba(245, 158, 11)">多次</span>建立连接。</span>
   createLocalToken: 创建本地令牌
@@ -1065,6 +1067,8 @@ multiplayer:
   gatheringIce: >
     请将<span class="v-chip v-chip--label v-size--small" style="text-font: bold">本地令牌</span>发送给您的联机伙伴，您的联机伙伴在 <span class="v-chip v-chip--label v-size--small" style="text-font: bold"> 加入连接 </span> 中输入这段文字。 <br> 期间 ICE 服务器可能需要时间收集足够信息来创建<span class="v-chip v-chip--label v-size--small" style="text-font: bold">本地令牌</span>。 <br> <span class="hint-text"> 您不需要等 ICE 服务器完全收集完毕，当下面的令牌已经有内容并且不怎么变化后，您可以提前将令牌复制给对方。 </span>
   groupId: 小组 ID
+  guest: 玩家
+  host: 房主
   illegalTokenDescription: 非法的令牌，请确认对方给您的令牌是完整且正确的。
   initiateConnection: 发起连接
   joinConnection: 如果您的伙伴已经创建了连接，您需要选择加入链接。
@@ -1087,6 +1091,7 @@ multiplayer:
   receiveHint: 在对方输入您的令牌后，您们之间的连接会自动创建。现在您已经可以点击完成了。
   receiveRemoteTokenHint: 请将联机伙伴的令牌粘贴在此处，并点击下一步。
   remoteToken: 对方的令牌
+  relayConnection: 中继
   routerInfo: 路由器信息
   sendTokenToRemote: 将本地令牌给您的联机伙伴
   share: 分享启动配置

--- a/xmcl-keystone-ui/src/composables/peers.ts
+++ b/xmcl-keystone-ui/src/composables/peers.ts
@@ -20,7 +20,7 @@ export function usePeerConnections() {
   watch(state, (s) => {
     if (!s) return
     s.subscribe('connectionShareManifest', ({ id, manifest }) => {
-      const info = s.connections.find(c => c.id === id)
+      const info = s.connections.find((c) => c.id === id)
       const name = info?.userInfo.name || id.substring(0, 6)
       const show = () => {
         if (manifest) {
@@ -28,31 +28,38 @@ export function usePeerConnections() {
             icon: info?.userInfo.avatar,
             title: t('multiplayer.sharingNotificationTitle'),
             body: t('multiplayer.sharingNotificationBody', { name }),
-            operations: [{
-              text: t('shared.download'),
-              icon: 'download',
-              handler() {
-                showShareInstance(manifest)
+            operations: [
+              {
+                text: t('shared.download'),
+                icon: 'download',
+                handler() {
+                  showShareInstance(manifest)
+                },
               },
-            }, {
-              text: t('instances.add'),
-              icon: 'add',
-              color: 'primary',
-              handler() {
-                showAddInstance({
-                  format: 'manifest',
-                  manifest,
-                })
+              {
+                text: t('instances.add'),
+                icon: 'add',
+                color: 'primary',
+                handler() {
+                  showAddInstance({
+                    format: 'manifest',
+                    manifest,
+                  })
+                },
               },
-            }],
+            ],
           })
         }
       }
       if (!document.hasFocus()) {
         windowController.flashFrame()
-        window.addEventListener('focus', () => {
-          show()
-        }, { once: true })
+        window.addEventListener(
+          'focus',
+          () => {
+            show()
+          },
+          { once: true },
+        )
       } else {
         show()
       }
@@ -67,7 +74,16 @@ export const kPeerState: InjectionKey<ReturnType<typeof usePeerState>> = Symbol(
 
 export function usePeerState(gameProfile: Ref<GameProfileAndTexture>) {
   const { getPeerState, exposePort, unexposePort } = useService(PeerServiceKey)
-  const { initiate, setRemoteDescription, drop, refreshNat, isReady, setUserInfo, leaveGroup, joinGroup } = multiplayer
+  const {
+    initiate,
+    setRemoteDescription,
+    drop,
+    refreshNat,
+    isReady,
+    setUserInfo,
+    leaveGroup,
+    joinGroup,
+  } = multiplayer
 
   const { state } = useState(getPeerState, PeerState)
 
@@ -88,17 +104,23 @@ export function usePeerState(gameProfile: Ref<GameProfileAndTexture>) {
   const connections = computed(() => state.value?.connections ?? [])
   const validIceServers = computed(() => state.value?.validIceServers ?? [])
   const ips = computed(() => state.value?.ips ?? [])
-  const exposedPorts = computed(() => state.value?.exposedPorts.map(v => v[0]) ?? [])
+  const exposedPorts = computed(() => state.value?.exposedPorts.map((v) => v[0]) ?? [])
 
-  watch(gameProfile, (p) => {
-    setUserInfo({
-      ...p,
-      name: p.name,
-      avatar: p.textures.SKIN.url,
-    })
-  }, { immediate: true })
+  watch(
+    gameProfile,
+    (p) => {
+      setUserInfo({
+        ...p,
+        name: p.name,
+        avatar: p.textures.SKIN.url,
+      })
+    },
+    { immediate: true },
+  )
 
   const group = computed(() => state.value?.group)
+  const groupRole = computed(() => state.value?.groupRole || '')
+  const groupMaxPeers = computed(() => state.value?.groupMaxPeers || 0)
   const groupState = computed(() => state.value?.groupState || 'closed')
   const icePings = computed(() => state.value?.icsServersPings || {})
   const groupPing = computed(() => state.value?.ping || NaN)
@@ -118,7 +140,9 @@ export function usePeerState(gameProfile: Ref<GameProfileAndTexture>) {
       otherExposedPorts.value = b.map(({ port, session }) => {
         return {
           port,
-          user: connections.value.find(c => c.id === session)?.userInfo.name || session.substring(0, 6),
+          user:
+            connections.value.find((c) => c.id === session)?.userInfo.name ||
+            session.substring(0, 6),
         }
       })
       buffer = []
@@ -149,6 +173,8 @@ export function usePeerState(gameProfile: Ref<GameProfileAndTexture>) {
     setRemoteDescription: _setRemoteDescription,
     initiate,
     group,
+    groupRole,
+    groupMaxPeers,
     icePings,
     groupPing,
     groupLastTimestamp,

--- a/xmcl-keystone-ui/src/views/Multiplayer.vue
+++ b/xmcl-keystone-ui/src/views/Multiplayer.vue
@@ -17,15 +17,20 @@
           {{ tGroupState[groupState] }}
 
           <v-chip v-if="groupState === 'connected'" size="small" label color="primary">
-            <v-icon start> signal_cellular_alt </v-icon>
-            {{ groupPing + 'ms' }}
-
-            {{ pingAgo }}
+            <v-icon start>{{ groupRole === 'host' ? 'home' : 'person' }}</v-icon>
+            {{ groupRole === 'host' ? t('multiplayer.host') : t('multiplayer.guest') }}
+            <template v-if="groupRole === 'host' && groupMaxPeers">
+              · {{ connections.length + 1 }}/{{ groupMaxPeers }}
+            </template>
           </v-chip>
 
           <div class="hidden text-sm text-gray-400 lg:block">
             <template v-if="group">
-              {{ t('multiplayer.copyGroupToFriendHint') }}
+              {{
+                groupRole === 'host'
+                  ? t('multiplayer.copyGroupToFriendHint')
+                  : t('multiplayer.connectedToHost')
+              }}
             </template>
             <template v-else>
               {{ t('multiplayer.joinOrCreateGroupHint') }}
@@ -101,7 +106,7 @@
           </v-btn>
           <v-btn
             v-shared-tooltip.left="() => (copied ? t('multiplayer.copied') : t('multiplayer.copy'))"
-            :disabled="!group"
+            :disabled="!group || groupState !== 'connected'"
             variant="text"
             icon
             @click="onCopy(groupId)"
@@ -258,6 +263,17 @@
                 <span class="hidden lg:inline"> {{ t(`peerConnectionState.name`) }}: </span>
                 {{ tConnectionStates[c.connectionState] }}
                 <template v-if="c.connectionState === 'connected'"> ({{ c.ping }}ms) </template>
+              </v-chip>
+              <v-chip
+                v-if="c.connectionState === 'connected' && c.selectedCandidate"
+                label
+                size="small"
+                :color="isRelay(c) ? 'warning' : 'success'"
+              >
+                <v-icon start>{{ isRelay(c) ? 'swap_vert' : 'bolt' }}</v-icon>
+                {{
+                  isRelay(c) ? t('multiplayer.relayConnection') : t('multiplayer.directConnection')
+                }}
               </v-chip>
             </v-list-item-subtitle>
             <template #append>
@@ -476,14 +492,13 @@ import Hint from '@/components/Hint.vue'
 import PlayerAvatar from '@/components/PlayerAvatar.vue'
 import SimpleDialog from '@/components/SimpleDialog.vue'
 import { useService } from '@/composables'
-import { useDateString } from '@/composables/date'
 import { AddInstanceDialogKey } from '@/composables/instanceTemplates'
 import { kPeerState } from '@/composables/peers'
 import { kTheme } from '@/composables/theme'
 import { kUserContext } from '@/composables/user'
 import { vSharedTooltip } from '@/directives/sharedTooltip'
 import { injection } from '@/util/inject'
-import { useIntervalFn, useLocalStorage } from '@vueuse/core'
+import { useLocalStorage } from '@vueuse/core'
 import { AUTHORITY_MICROSOFT, BaseServiceKey } from '@xmcl/runtime-api'
 import { useDialog, useSimpleDialog } from '../composables/dialog'
 import MultiplayerDialogInitiate from './MultiplayerDialogInitiate.vue'
@@ -518,10 +533,10 @@ const {
   connections,
   turnservers,
   group,
+  groupRole,
+  groupMaxPeers,
   groupState,
   icePings,
-  groupPing,
-  groupLastTimestamp,
   joinGroup,
   leaveGroup,
   drop,
@@ -542,12 +557,10 @@ const { users } = injection(kUserContext)
 const hasMicrosoft = computed(() => !!users.value.find((u) => u.authority === AUTHORITY_MICROSOFT))
 const forwardedPort = ref(0)
 
-const allowTurn = useLocalStorage('peerAllowTurn', false, { writeDefaults: false })
-const kernel = useLocalStorage<'node-datachannel' | 'webrtc'>(
-  'peerKernel',
-  'node-datachannel',
-  { writeDefaults: false },
-)
+const allowTurn = useLocalStorage('peerAllowTurn', true, { writeDefaults: false })
+const kernel = useLocalStorage<'node-datachannel' | 'webrtc'>('peerKernel', 'node-datachannel', {
+  writeDefaults: false,
+})
 const kernels = computed(() => [
   { value: 'node-datachannel', text: 'node-datachannel' },
   { value: 'webrtc', text: 'WebRTC' },
@@ -657,27 +670,9 @@ const tConnectionStates = computed(() => ({
   new: t('peerConnectionState.new'),
 }))
 
-const { getDateString } = useDateString()
-const pingAgo = ref('')
-const interval = useIntervalFn(
-  () => {
-    pingAgo.value = `(${getDateString(groupLastTimestamp.value)})`
-  },
-  1_000,
-  { immediate: false },
-)
-
-watch(
-  groupState,
-  (newVal) => {
-    if (newVal === 'connected') {
-      interval.resume()
-    } else {
-      interval.pause()
-    }
-  },
-  { immediate: true },
-)
+const isRelay = (connection: (typeof connections.value)[number]) =>
+  connection.selectedCandidate?.local.type === 'relay' ||
+  connection.selectedCandidate?.remote.type === 'relay'
 
 const edit = (id: string, init: boolean) => {
   const conn = connections.value.find((c) => c.id === id)

--- a/xmcl-runtime-api/src/multiplayer.ts
+++ b/xmcl-runtime-api/src/multiplayer.ts
@@ -8,9 +8,21 @@ export interface RTCSessionDescription {
   type: 'answer' | 'offer' | 'pranswer' | 'rollback'
 }
 
-export type ConnectionState = 'closed' | 'connected' | 'connecting' | 'disconnected' | 'failed' | 'new'
+export type ConnectionState =
+  | 'closed'
+  | 'connected'
+  | 'connecting'
+  | 'disconnected'
+  | 'failed'
+  | 'new'
 export type IceGatheringState = 'complete' | 'gathering' | 'new'
-export type SignalingState = 'closed' | 'have-local-offer' | 'have-local-pranswer' | 'have-remote-offer' | 'have-remote-pranswer' | 'stable'
+export type SignalingState =
+  | 'closed'
+  | 'have-local-offer'
+  | 'have-local-pranswer'
+  | 'have-remote-offer'
+  | 'have-remote-pranswer'
+  | 'stable'
 
 export interface SelectedCandidateInfo {
   address: string
@@ -93,6 +105,25 @@ export interface SetRemoteDescriptionOptions {
   description: string | TransferDescription
 }
 
+export interface MultiplayerRoomAdmission {
+  roomId: string
+  socketUrl: string
+  ticket: string
+  peerId: string
+  expiresAt: string
+  role: 'host' | 'guest'
+  maxPeers?: number
+}
+
+export interface MultiplayerIceServerCredential {
+  uris?: string[]
+  ttl?: number
+  password?: string
+  username?: string
+  stuns: string[]
+  meta?: Record<string, string>
+}
+
 export interface Multiplayer extends GenericEventEmitter<MultiplayerEvents> {
   /**
    * Is the multiplayer module ready
@@ -124,12 +155,7 @@ export interface Multiplayer extends GenericEventEmitter<MultiplayerEvents> {
    * @param id The session to drop
    */
   drop(id: string): Promise<void>
-  /**
-   * Join the group.
-   * The group will automatically create connection between group members.
-   *
-   * @param groupId The group id
-   */
+  /** Create a Host room when `groupId` is empty, otherwise join as a Guest. */
   joinGroup(groupId: string): Promise<void>
   /**
    * Leave the group

--- a/xmcl-runtime-api/src/services/PeerService.ts
+++ b/xmcl-runtime-api/src/services/PeerService.ts
@@ -1,10 +1,25 @@
 import type { InstanceManifest } from '../entities/instanceManifest.schema'
 import type { GenericEventEmitter } from '../events'
-import type { ConnectionState, ConnectionUserInfo, IceGatheringState, Peer, SelectedCandidateInfo, SignalingState } from '../multiplayer'
+import type {
+  ConnectionState,
+  ConnectionUserInfo,
+  IceGatheringState,
+  Peer,
+  SelectedCandidateInfo,
+  SignalingState,
+} from '../multiplayer'
 import type { SharedState } from '../util/SharedState'
 import type { ServiceKey } from './Service'
 
-export type NatType = 'Blocked' | 'Open Internet' | 'Full Cone' | 'Symmetric UDP Firewall' | 'Restrict NAT' | 'Restrict Port NAT' | 'Symmetric NAT' | 'Unknown'
+export type NatType =
+  | 'Blocked'
+  | 'Open Internet'
+  | 'Full Cone'
+  | 'Symmetric UDP Firewall'
+  | 'Restrict NAT'
+  | 'Restrict Port NAT'
+  | 'Symmetric NAT'
+  | 'Unknown'
 
 export interface NatDeviceInfo {
   deviceType: string
@@ -24,6 +39,8 @@ export class PeerState {
   ips = [] as string[]
   turnservers = {} as Record<string, string>
   group = ''
+  groupRole: 'host' | 'guest' | '' = ''
+  groupMaxPeers = 0
   groupState: 'connecting' | 'connected' | 'closing' | 'closed' = 'closed'
   groupError?: Error
 
@@ -35,7 +52,7 @@ export class PeerState {
   ping = 0
   timestamp = 0
 
-  pingSet({ ping, timestamp }: { ping: number, timestamp: number }) {
+  pingSet({ ping, timestamp }: { ping: number; timestamp: number }) {
     this.ping = ping
     this.timestamp = timestamp
   }
@@ -48,9 +65,21 @@ export class PeerState {
     this.natType = type
   }
 
-  groupSet({ group, state }: { group: string; state: 'connecting' | 'connected' | 'closing' | 'closed' }) {
+  groupSet({
+    group,
+    state,
+    role = '',
+    maxPeers = 0,
+  }: {
+    group: string
+    state: 'connecting' | 'connected' | 'closing' | 'closed'
+    role?: 'host' | 'guest' | ''
+    maxPeers?: number
+  }) {
     this.group = group
     this.groupState = state
+    this.groupRole = role
+    this.groupMaxPeers = maxPeers
   }
 
   groupStateSet(state: 'connecting' | 'connected' | 'closing' | 'closed') {
@@ -66,39 +95,39 @@ export class PeerState {
   }
 
   connectionUserInfo({ id, info }: { id: string; info: ConnectionUserInfo }) {
-    const conn = this.connections.find(c => c.id === id)
+    const conn = this.connections.find((c) => c.id === id)
     if (conn) {
       conn.userInfo = info
     }
   }
 
   connectionShareManifest({ id, manifest }: { id: string; manifest?: InstanceManifest }) {
-    const conn = this.connections.find(c => c.id === id)
+    const conn = this.connections.find((c) => c.id === id)
     if (conn) {
       conn.sharing = manifest
     }
   }
 
   connectionRemoteSet({ id, remoteId }: { id: string; remoteId: string }) {
-    const conn = this.connections.find(c => c.id === id)
+    const conn = this.connections.find((c) => c.id === id)
     if (conn) {
       conn.remoteId = remoteId
     }
   }
 
   connectionAdd(connection: Peer) {
-    if (this.connections.find(c => c.id === connection.id)) {
+    if (this.connections.find((c) => c.id === connection.id)) {
       return
     }
     this.connections = [...this.connections, connection]
   }
 
   connectionDrop(connectionId: string) {
-    this.connections = this.connections.filter(c => c.id !== connectionId)
+    this.connections = this.connections.filter((c) => c.id !== connectionId)
   }
 
   connectionIceServerSet({ id, iceServer }: { id: string; iceServer: RTCIceServer }) {
-    const conn = this.connections.find(c => c.id === id)
+    const conn = this.connections.find((c) => c.id === id)
     if (conn) {
       if (conn.iceServer) {
         conn.triedIceServers.push(conn.iceServer)
@@ -108,25 +137,29 @@ export class PeerState {
   }
 
   connectionLocalDescription(update: { id: string; description: string }) {
-    const conn = this.connections.find(c => c.id === update.id)
+    const conn = this.connections.find((c) => c.id === update.id)
     if (conn) {
       conn.localDescriptionSDP = update.description
     }
   }
 
   connectionStateChange(update: { id: string; connectionState: ConnectionState }) {
-    const conn = this.connections.find(c => c.id === update.id)
+    const conn = this.connections.find((c) => c.id === update.id)
     if (conn) {
       conn.connectionState = update.connectionState
     }
   }
 
-  connectionSelectedCandidate({ id, local, remote }: {
+  connectionSelectedCandidate({
+    id,
+    local,
+    remote,
+  }: {
     id: string
     local: SelectedCandidateInfo
     remote: SelectedCandidateInfo
   }) {
-    const conn = this.connections.find(c => c.id === id)
+    const conn = this.connections.find((c) => c.id === id)
     if (conn) {
       conn.selectedCandidate = {
         local,
@@ -136,35 +169,35 @@ export class PeerState {
   }
 
   connectionPing(update: { id: string; ping: number }) {
-    const conn = this.connections.find(c => c.id === update.id)
+    const conn = this.connections.find((c) => c.id === update.id)
     if (conn) {
       conn.ping = update.ping
     }
   }
 
   connectionPreferredIceServers({ id, servers }: { id: string; servers: RTCIceServer[] }) {
-    const conn = this.connections.find(c => c.id === id)
+    const conn = this.connections.find((c) => c.id === id)
     if (conn) {
       conn.preferredIceServers = servers
     }
   }
 
   iceGatheringStateChange(update: { id: string; iceGatheringState: IceGatheringState }) {
-    const conn = this.connections.find(c => c.id === update.id)
+    const conn = this.connections.find((c) => c.id === update.id)
     if (conn) {
       conn.iceGatheringState = update.iceGatheringState
     }
   }
 
   signalingStateChange(update: { id: string; signalingState: SignalingState }) {
-    const conn = this.connections.find(c => c.id === update.id)
+    const conn = this.connections.find((c) => c.id === update.id)
     if (conn) {
       conn.signalingState = update.signalingState
     }
   }
 
   connectionIceServersSet({ id, iceServer }: { id: string; iceServer: RTCIceServer }) {
-    const conn = this.connections.find(c => c.id === id)
+    const conn = this.connections.find((c) => c.id === id)
     if (conn) {
       conn.iceServer = iceServer
       conn.triedIceServers = [...conn.triedIceServers, conn.iceServer]
@@ -207,8 +240,8 @@ interface PeerServiceEvents {
 export interface PeerService extends GenericEventEmitter<PeerServiceEvents> {
   getPeerState(): Promise<SharedState<PeerState>>
   /**
-    * Share the instance to other peers
-    */
+   * Share the instance to other peers
+   */
   shareInstance(options: ShareInstanceOptions): Promise<void>
 
   exposePort(port: number, protocol: number): Promise<void>

--- a/xmcl-runtime/peer/PeerService.ts
+++ b/xmcl-runtime/peer/PeerService.ts
@@ -1,8 +1,21 @@
-import { PeerService as IPeerService, SharedState, PeerServiceKey, PeerState, ShareInstanceOptions } from '@xmcl/runtime-api'
+import {
+  PeerService as IPeerService,
+  SharedState,
+  PeerServiceKey,
+  PeerState,
+  ShareInstanceOptions,
+} from '@xmcl/runtime-api'
 import { Inject, LauncherApp, LauncherAppKey, kGameDataPath } from '~/app'
 import { ExposeServiceKey, ServiceStateManager, StatefulService } from '~/service'
 import { kPeerFacade } from './PeerServiceFacade'
 import { kClientToken } from '~/infra'
+import {
+  CommercialAccountService,
+  kCommercialSessionAuthorization,
+} from '~/commercialAccount/CommercialAccountService'
+import { resolveXmclApiBaseUrl } from '~/app/xmclApiBaseUrl'
+import type { MultiplayerIceServerCredential, MultiplayerRoomAdmission } from '@xmcl/runtime-api'
+import { UserService } from '~/user'
 
 @ExposeServiceKey(PeerServiceKey)
 export class PeerService extends StatefulService<PeerState> implements IPeerService {
@@ -10,7 +23,11 @@ export class PeerService extends StatefulService<PeerState> implements IPeerServ
     @Inject(LauncherAppKey) app: LauncherApp,
     @Inject(ServiceStateManager) store: ServiceStateManager,
   ) {
-    super(app, () => store.registerStatic(new PeerState(), PeerServiceKey), async () => { })
+    super(
+      app,
+      () => store.registerStatic(new PeerState(), PeerServiceKey),
+      async () => {},
+    )
 
     let port = 25566
     app.controller.handle('multiplayer-port', async (ev, p: number) => {
@@ -25,9 +42,86 @@ export class PeerService extends StatefulService<PeerState> implements IPeerServ
         sessionId,
       }
     })
+    const multiplayerApiBaseUrl = resolveXmclApiBaseUrl(
+      'https://xmcl-web-api.cijhn.workers.dev',
+      app.getLogger('MultiplayerApi'),
+    )
+    const requestRoom = async (
+      path: string,
+      init: RequestInit,
+    ): Promise<MultiplayerRoomAdmission | undefined> => {
+      const account = await app.registry.get(CommercialAccountService)
+      const authorization = await account[kCommercialSessionAuthorization]()
+      if (!authorization) throw new Error('commercial_account_session_missing')
+      const headers = new Headers(init.headers)
+      headers.set('Content-Type', 'application/json')
+      headers.set('authorization', ['Bearer', authorization.accessToken].join(' '))
+      const response = await app.fetch(new URL(path, multiplayerApiBaseUrl), {
+        ...init,
+        headers,
+      })
+      if (!response.ok) {
+        const body = (await response.json().catch(() => ({}))) as { message?: string }
+        throw new Error(body.message || `multiplayer_room_request_failed:${response.status}`)
+      }
+      if (response.status === 204) return undefined
+      const admission = (await response.json()) as MultiplayerRoomAdmission
+      const socketUrl = new URL(admission.socketUrl, multiplayerApiBaseUrl)
+      socketUrl.protocol = socketUrl.protocol === 'https:' ? 'wss:' : 'ws:'
+      return { ...admission, socketUrl: socketUrl.toString() }
+    }
+    app.controller.handle(
+      'multiplayer-room-create',
+      async (_event, input: { displayName: string; maxPeers?: number }) => {
+        const admission = await requestRoom('/v2/multiplayer/rooms', {
+          method: 'POST',
+          body: JSON.stringify(input),
+        })
+        return admission && { ...admission, role: 'host' as const }
+      },
+    )
+    app.controller.handle(
+      'multiplayer-room-join',
+      async (_event, input: { roomId: string; displayName: string }) => {
+        const admission = await requestRoom(
+          `/v2/multiplayer/rooms/${encodeURIComponent(input.roomId)}/join`,
+          {
+            method: 'POST',
+            body: JSON.stringify({ displayName: input.displayName }),
+          },
+        )
+        return admission && { ...admission, role: 'guest' as const }
+      },
+    )
+    app.controller.handle('multiplayer-room-close', async (_event, roomId: string) => {
+      await requestRoom(`/v2/multiplayer/rooms/${encodeURIComponent(roomId)}`, {
+        method: 'DELETE',
+      })
+    })
+    app.controller.handle(
+      'multiplayer-ice-servers',
+      async (): Promise<MultiplayerIceServerCredential> => {
+        const official = await app.registry
+          .get(UserService)
+          .then((service) => service.getOfficialUserProfile())
+        const headers = new Headers()
+        if (official?.accessToken) {
+          headers.set('authorization', ['Bearer', official.accessToken].join(' '))
+        }
+        const response = await app.fetch(new URL('/rtc/official', multiplayerApiBaseUrl), {
+          method: 'POST',
+          headers,
+        })
+        if (!response.ok) {
+          throw new Error(`multiplayer_ice_server_request_failed:${response.status}`)
+        }
+        return (await response.json()) as MultiplayerIceServerCredential
+      },
+    )
 
     const queryGameProfile = async (name: string) => {
-      return this.state.connections.find(c => c.userInfo.name === name || c.userInfo.id === name)?.userInfo
+      return this.state.connections.find((c) => c.userInfo.name === name || c.userInfo.id === name)
+        ?.userInfo
     }
 
     app.registry.register(kPeerFacade, {
@@ -41,7 +135,9 @@ export class PeerService extends StatefulService<PeerState> implements IPeerServ
         const orignalFilePath = decodeURI(peerUrl.pathname)
         const urlBase64 = Buffer.from(orignalFilePath).toString('base64url')
 
-        const realUrl = new URL(`http://localhost:${port}/files/${peerUrl.host}?path=${urlBase64}`).toString()
+        const realUrl = new URL(
+          `http://localhost:${port}/files/${peerUrl.host}?path=${urlBase64}`,
+        ).toString()
 
         return realUrl
       },

--- a/xmcl-runtime/peer/PeerService.ts
+++ b/xmcl-runtime/peer/PeerService.ts
@@ -8,11 +8,8 @@ import {
 import { Inject, LauncherApp, LauncherAppKey, kGameDataPath } from '~/app'
 import { ExposeServiceKey, ServiceStateManager, StatefulService } from '~/service'
 import { kPeerFacade } from './PeerServiceFacade'
-import { kClientToken } from '~/infra'
-import {
-  CommercialAccountService,
-  kCommercialSessionAuthorization,
-} from '~/commercialAccount/CommercialAccountService'
+import { kClientToken, kFlights } from '~/infra'
+import { kXmclSessionAuthorization, XmclAccountService } from '~/xmclAccount/XmclAccountService'
 import { resolveXmclApiBaseUrl } from '~/app/xmclApiBaseUrl'
 import type { MultiplayerIceServerCredential, MultiplayerRoomAdmission } from '@xmcl/runtime-api'
 import { UserService } from '~/user'
@@ -42,17 +39,18 @@ export class PeerService extends StatefulService<PeerState> implements IPeerServ
         sessionId,
       }
     })
-    const multiplayerApiBaseUrl = resolveXmclApiBaseUrl(
-      'https://xmcl-web-api.cijhn.workers.dev',
-      app.getLogger('MultiplayerApi'),
-    )
+    const getMultiplayerApiBaseUrl = async () => {
+      const flights = await app.registry.get(kFlights)
+      return resolveXmclApiBaseUrl(flights.xmclApiBaseUrl, app.getLogger('MultiplayerApi'))
+    }
     const requestRoom = async (
       path: string,
       init: RequestInit,
     ): Promise<MultiplayerRoomAdmission | undefined> => {
-      const account = await app.registry.get(CommercialAccountService)
-      const authorization = await account[kCommercialSessionAuthorization]()
-      if (!authorization) throw new Error('commercial_account_session_missing')
+      const account = await app.registry.get(XmclAccountService)
+      const authorization = await account[kXmclSessionAuthorization]()
+      if (!authorization) throw new Error('xmcl_account_session_missing')
+      const multiplayerApiBaseUrl = await getMultiplayerApiBaseUrl()
       const headers = new Headers(init.headers)
       headers.set('Content-Type', 'application/json')
       headers.set('authorization', ['Bearer', authorization.accessToken].join(' '))
@@ -101,6 +99,7 @@ export class PeerService extends StatefulService<PeerState> implements IPeerServ
     app.controller.handle(
       'multiplayer-ice-servers',
       async (): Promise<MultiplayerIceServerCredential> => {
+        const multiplayerApiBaseUrl = await getMultiplayerApiBaseUrl()
         const official = await app.registry
           .get(UserService)
           .then((service) => service.getOfficialUserProfile())


### PR DESCRIPTION
## Summary
- replace v1 group heartbeat discovery with authenticated multiplayer v2 rooms
- keep one Host signaling WebSocket and use temporary Guest signaling for Host-only WebRTC
- call room control APIs with the private XMCL account session from M1; Minecraft tokens are used only to obtain the existing built-in TURN credentials
- add Host control restoration, bounded signaling reconnects, ICE server fallback, and Guest cleanup
- show Host/Guest role, room capacity, and direct versus relay transport in the multiplayer UI

## Dependencies
- stacked on launcher PR #1619 (eat/m1-account) for XMCL account sessions
- requires web API PR Voxelum/xmcl-web-api#12

## Validation
- TypeScript checks: @xmcl/wrtc-multiplayer, @xmcl/runtime-api, @xmcl/runtime, Electron app/preload, Keystone UI
- 12 targeted tests covering signaling lifecycle, rejected upgrades, built-in TURN credentials, and M1 session behavior
