### PR TITLE
feat(agent): add provider presets with per-provider API keys

### DIFF
--- a/xmcl-keystone-ui/locales/en.yaml
+++ b/xmcl-keystone-ui/locales/en.yaml
@@ -46,6 +46,7 @@ agent:
   emptyHint: >-
     Ask the agent to inspect your instance, toggle mods, read logs, or diagnose
     a crash.
+  errorTitle: The agent hit an error
   inputPlaceholder: Ask the agent…  (Enter to send, Shift+Enter for newline)
   notConfiguredHint: >-
     Set your API key, model and endpoint in Settings → General → AI Agent to
@@ -1663,11 +1664,18 @@ setting:
   advancedSettings: Advanced Settings
   advancedSettingsHint: Danger zone - reset or manage launcher data
   aiAgentApiKey: AI Agent API Key
+  aiAgentApiKeyClear: Clear key
   aiAgentApiKeyDescription: Stored locally on this device and used for agent requests.
+  aiAgentApiKeyEmpty: Paste your API key
+  aiAgentApiKeySaved: Saved
+  aiAgentApiKeyStored: Key saved - type to replace
   aiAgentEndpoint: AI Agent Endpoint
   aiAgentEndpointDescription: Chat completions endpoint URL.
   aiAgentModel: AI Agent Model
   aiAgentModelDescription: Model name to send in chat completion requests.
+  aiAgentProvider: AI Agent Provider
+  aiAgentProviderCustom: Custom (OpenAI compatible)
+  aiAgentProviderDescription: Pick a preset OpenAI-compatible provider to fill the endpoint.
   apiSets:
     auto: Auto (Determine by network)
     official: Official (Mojang)

--- a/xmcl-keystone-ui/locales/en.yaml
+++ b/xmcl-keystone-ui/locales/en.yaml
@@ -1667,6 +1667,8 @@ setting:
   aiAgentApiKeyClear: Clear key
   aiAgentApiKeyDescription: Stored locally on this device and used for agent requests.
   aiAgentApiKeyEmpty: Paste your API key
+  aiAgentApiKeyNotNeeded: Not required
+  aiAgentApiKeyNotNeededHint: This provider runs locally and needs no API key
   aiAgentApiKeySaved: Saved
   aiAgentApiKeyStored: Key saved - type to replace
   aiAgentEndpoint: AI Agent Endpoint

--- a/xmcl-keystone-ui/locales/zh-CN.yaml
+++ b/xmcl-keystone-ui/locales/zh-CN.yaml
@@ -57,6 +57,7 @@ agent:
   confirmTitle: 确认 Agent 操作
   confirmCancel: 取消
   confirmAccept: 继续
+  errorTitle: Agent 执行出错
   inputPlaceholder: 向 Agent 提问…（Enter 发送，Shift+Enter 换行）
   disabledPlaceholder: Agent 已禁用
   toolArguments: 参数
@@ -1420,11 +1421,18 @@ setting:
   advancedSettings: 高级设置
   advancedSettingsHint: 危险区域 - 重置或管理启动器数据
   aiAgentApiKey: AI Agent API Key
+  aiAgentApiKeyClear: 清除密钥
   aiAgentApiKeyDescription: 仅保存在本地设备，用于 Agent 请求。
+  aiAgentApiKeyEmpty: 粘贴你的 API Key
+  aiAgentApiKeySaved: 已保存
+  aiAgentApiKeyStored: 已保存密钥，输入可替换
   aiAgentEndpoint: AI Agent Endpoint
   aiAgentEndpointDescription: 聊天补全（chat completions）的 Endpoint 地址。
   aiAgentModel: AI Agent 模型
   aiAgentModelDescription: 请求聊天补全时使用的模型名。
+  aiAgentProvider: AI Agent 服务商
+  aiAgentProviderCustom: 自定义（OpenAI 兼容）
+  aiAgentProviderDescription: 选择预设的 OpenAI 兼容服务商以自动填充 Endpoint。
   apiSets:
     auto: 自动 (根据网络决定)
     official: 官方 (Mojang)

--- a/xmcl-keystone-ui/locales/zh-CN.yaml
+++ b/xmcl-keystone-ui/locales/zh-CN.yaml
@@ -1424,6 +1424,8 @@ setting:
   aiAgentApiKeyClear: 清除密钥
   aiAgentApiKeyDescription: 仅保存在本地设备，用于 Agent 请求。
   aiAgentApiKeyEmpty: 粘贴你的 API Key
+  aiAgentApiKeyNotNeeded: 无需密钥
+  aiAgentApiKeyNotNeededHint: 该服务在本地运行，无需 API Key
   aiAgentApiKeySaved: 已保存
   aiAgentApiKeyStored: 已保存密钥，输入可替换
   aiAgentEndpoint: AI Agent Endpoint

--- a/xmcl-keystone-ui/src/composables/agent/settings.ts
+++ b/xmcl-keystone-ui/src/composables/agent/settings.ts
@@ -82,13 +82,26 @@ export const useAgentSettings = createSharedComposable(() => {
   async function setApiKey(value: string) {
     apiKey.value = value
     await ready
+    // Capture the endpoint at call time. If the user switches provider while this
+    // write is queued behind an earlier one, the key must still be filed under the
+    // provider it was typed for -- and must not resurrect settings for that
+    // provider over the newly selected one.
+    const target = endpoint.value
+    const targetModel = model.value
     keySave = keySave.then(async () => {
       try {
-        await service.setProviderSettings({ endpoint: endpoint.value, model: model.value, apiKey: value })
-        configured.value = !!value.trim()
-        error.value = ''
+        await service.setProviderSettings({ endpoint: target, model: targetModel, apiKey: value })
+        // Only reflect the result in the UI if that provider is still selected.
+        if (endpoint.value === target) {
+          configured.value = !!value.trim()
+          error.value = ''
+        } else {
+          // The endpoint just committed belongs to the previous provider; restore
+          // the current selection so settings and UI do not drift apart.
+          await service.setProviderSettings({ endpoint: endpoint.value, model: model.value })
+        }
       } catch (e) {
-        error.value = e instanceof Error ? e.message : String(e)
+        if (endpoint.value === target) error.value = e instanceof Error ? e.message : String(e)
       }
     })
     await keySave
@@ -131,6 +144,8 @@ export const useAgentSettings = createSharedComposable(() => {
   /** The preset matching the current endpoint, or the custom id when none matches. */
   const providerId = computed(() => resolveAgentProviderId(resolvedEndpoint.value))
   const provider = computed(() => getAgentProviderPreset(providerId.value))
+  /** True when the selected provider needs no API key at all. */
+  const keyless = computed(() => !!provider.value?.keyless)
 
   /**
    * API keys are stored per provider and never read back into the renderer, so on a
@@ -145,7 +160,10 @@ export const useAgentSettings = createSharedComposable(() => {
     apiKey.value = ''
     configured.value = false
     const token = ++refreshToken
-    void flush().then(async () => {
+    // Wait for any key write that was already in flight: it commits the previous
+    // provider's endpoint, so reading `configured` before it settles would report
+    // the wrong provider's state.
+    void keySave.then(() => flush()).then(async () => {
       const settings = await service.getProviderSettings()
       // Ignore a stale response if the user switched again while this was in flight.
       if (token === refreshToken) configured.value = settings.configured
@@ -186,6 +204,7 @@ export const useAgentSettings = createSharedComposable(() => {
     providers: AGENT_PROVIDER_PRESETS,
     providerId,
     provider,
+    keyless,
     selectProvider,
   }
 })

--- a/xmcl-keystone-ui/src/composables/agent/settings.ts
+++ b/xmcl-keystone-ui/src/composables/agent/settings.ts
@@ -1,5 +1,13 @@
 import { createSharedComposable } from '@vueuse/core'
-import { AgentServiceKey, DEFAULT_AGENT_ENDPOINT, DEFAULT_AGENT_MODEL } from '@xmcl/runtime-api'
+import {
+  AGENT_PROVIDER_PRESETS,
+  AgentServiceKey,
+  CUSTOM_AGENT_PROVIDER_ID,
+  DEFAULT_AGENT_ENDPOINT,
+  DEFAULT_AGENT_MODEL,
+  getAgentProviderPreset,
+  resolveAgentProviderId,
+} from '@xmcl/runtime-api'
 import { useService } from '../service'
 
 const DEFAULT_AGNES_ENDPOINT = DEFAULT_AGENT_ENDPOINT
@@ -18,6 +26,7 @@ export const useAgentSettings = createSharedComposable(() => {
   const loaded = ref(false)
   const error = ref('')
   let saveTimer: ReturnType<typeof setTimeout> | undefined
+  let keyTimer: ReturnType<typeof setTimeout> | undefined
   let keySave = Promise.resolve()
   let settingsSave = Promise.resolve()
 
@@ -85,8 +94,80 @@ export const useAgentSettings = createSharedComposable(() => {
     await keySave
   }
 
+  /**
+   * Debounced key entry. The debounce lives here rather than in the view so that a
+   * provider switch can cancel a still-pending write: otherwise a key typed for the
+   * previous provider would land under the newly selected one.
+   */
+  function updateApiKey(value: string) {
+    apiKey.value = value
+    if (keyTimer) clearTimeout(keyTimer)
+    keyTimer = setTimeout(() => {
+      keyTimer = undefined
+      void setApiKey(value)
+    }, 500)
+  }
+
+  function cancelPendingApiKey() {
+    if (!keyTimer) return
+    clearTimeout(keyTimer)
+    keyTimer = undefined
+  }
+
+  /**
+   * Forget the stored key for the currently selected provider. Writing an empty
+   * value deletes the secret rather than storing a blank one. Any pending
+   * debounced write is cancelled first, so a key typed moments earlier cannot
+   * land after the clear and silently resurrect it.
+   */
+  async function clearApiKey() {
+    cancelPendingApiKey()
+    await setApiKey('')
+  }
+
   const resolvedEndpoint = computed(() => endpoint.value.trim() || DEFAULT_AGNES_ENDPOINT)
   const resolvedModel = computed(() => model.value.trim() || DEFAULT_AGNES_MODEL)
+
+  /** The preset matching the current endpoint, or the custom id when none matches. */
+  const providerId = computed(() => resolveAgentProviderId(resolvedEndpoint.value))
+  const provider = computed(() => getAgentProviderPreset(providerId.value))
+
+  /**
+   * API keys are stored per provider and never read back into the renderer, so on a
+   * provider switch the input is cleared and `configured` is re-read for the newly
+   * selected provider. The endpoint must be persisted first, since the backend keys
+   * the secret off the saved endpoint.
+   */
+  let refreshToken = 0
+  watch(providerId, () => {
+    if (!loaded.value) return
+    cancelPendingApiKey()
+    apiKey.value = ''
+    configured.value = false
+    const token = ++refreshToken
+    void flush().then(async () => {
+      const settings = await service.getProviderSettings()
+      // Ignore a stale response if the user switched again while this was in flight.
+      if (token === refreshToken) configured.value = settings.configured
+    }).catch(e => {
+      if (token === refreshToken) error.value = e instanceof Error ? e.message : String(e)
+    })
+  })
+
+  /**
+   * Switch to a preset provider. The endpoint always follows the preset; the model
+   * only follows when it is empty or still the previous preset's default, so a model
+   * the user typed by hand is never silently discarded.
+   */
+  function selectProvider(id: string) {
+    if (id === CUSTOM_AGENT_PROVIDER_ID) return
+    const preset = getAgentProviderPreset(id)
+    if (!preset || preset.id === providerId.value) return
+    const previous = provider.value
+    const current = model.value.trim()
+    if (!current || current === previous?.defaultModel) model.value = preset.defaultModel
+    endpoint.value = preset.endpoint
+  }
 
   return {
     apiKey,
@@ -98,7 +179,13 @@ export const useAgentSettings = createSharedComposable(() => {
     ready,
     flush,
     setApiKey,
+    updateApiKey,
+    clearApiKey,
     resolvedEndpoint,
     resolvedModel,
+    providers: AGENT_PROVIDER_PRESETS,
+    providerId,
+    provider,
+    selectProvider,
   }
 })

--- a/xmcl-keystone-ui/src/composables/agent/toolSupport.test.ts
+++ b/xmcl-keystone-ui/src/composables/agent/toolSupport.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, test } from 'vitest'
+import { actionObjectSchema } from './toolSupport'
+
+describe('actionObjectSchema', () => {
+  const schema = actionObjectSchema(
+    ['navigate', 'confirm'],
+    { path: { type: 'string' }, message: { type: 'string' } },
+    'Which UI operation to run.',
+  ) as any
+
+  // DeepSeek rejects a tool whose schema has no top-level `type` with
+  // "schema must be a JSON Schema of 'type: object'". A Type.Union of per-action
+  // objects emits a bare `anyOf`, which is exactly that failure.
+  test('is a root object schema, not a bare anyOf', () => {
+    expect(schema.type).toBe('object')
+    expect(schema.anyOf).toBeUndefined()
+    expect(schema.oneOf).toBeUndefined()
+  })
+
+  test('requires only the action discriminator', () => {
+    expect(schema.required).toEqual(['action'])
+  })
+
+  test('exposes the actions as a string enum', () => {
+    expect(schema.properties.action).toMatchObject({
+      type: 'string',
+      enum: ['navigate', 'confirm'],
+    })
+  })
+
+  test('keeps the per-action fields as optional siblings', () => {
+    expect(schema.properties.path).toEqual({ type: 'string' })
+    expect(schema.properties.message).toEqual({ type: 'string' })
+  })
+})

--- a/xmcl-keystone-ui/src/composables/agent/toolSupport.ts
+++ b/xmcl-keystone-ui/src/composables/agent/toolSupport.ts
@@ -18,6 +18,31 @@ export function textResult<T>(value: T): AgentToolResult<T> {
   }
 }
 
+/**
+ * Build a flat object schema for a tool that dispatches on an `action` field.
+ *
+ * A `Type.Union` of per-action objects emits a bare `anyOf` with no top-level
+ * `type`, which stricter OpenAI-compatible providers (DeepSeek among them)
+ * reject outright with "schema must be a JSON Schema of 'type: object'". So the
+ * variants are flattened into one object: `action` becomes an enum and every
+ * other field is optional, with the per-action requirements described in the
+ * field docs and enforced at runtime by the handler.
+ */
+export function actionObjectSchema(
+  actions: string[],
+  properties: Record<string, unknown>,
+  actionDescription: string,
+) {
+  return Type.Unsafe({
+    type: 'object',
+    required: ['action'],
+    properties: {
+      action: { type: 'string', enum: actions, description: actionDescription },
+      ...properties,
+    },
+  })
+}
+
 export function createAgentTools(definitions: AgentToolDefinition[]): AgentTool[] {
   return definitions.map(definition => ({
     name: definition.name,

--- a/xmcl-keystone-ui/src/composables/agent/tools.ts
+++ b/xmcl-keystone-ui/src/composables/agent/tools.ts
@@ -31,7 +31,7 @@ import { kUserContext } from '../user'
 import { useAgentCapabilityContext } from './capabilityContext'
 import { createAgentManagementTools } from './managementTools'
 import { createAgentServerTools } from './serverTools'
-import { textResult } from './toolSupport'
+import { actionObjectSchema, textResult } from './toolSupport'
 import { buildAgentInstanceEdit, isAgentCommandAllowed } from './toolPolicy'
 
 function tokenize(input: string) {
@@ -59,6 +59,9 @@ function tokenize(input: string) {
   if (token) tokens.push(token)
   return tokens
 }
+
+/** Max resource entries returned per `vfs_list` page, to bound prompt size. */
+const RESOURCE_LIST_LIMIT = 10
 
 function summarizeResource(resource: Resource) {
   return {
@@ -144,7 +147,7 @@ export function useAgentToolFactory() {
       const service = kind === 'mods' ? modsService : kind === 'resourcepacks' ? resourcePackService : shaderPackService
       return (await service.watch(instancePath)).files
     }
-    const list = async (path: string) => {
+    const list = async (path: string, listOffset?: number) => {
       const clean = path.replace(/^\.?\//, '').replace(/\/$/, '')
       if (!clean) {
         return {
@@ -152,7 +155,21 @@ export function useAgentToolFactory() {
           entries: ['mods', 'resourcepacks', 'shaderpacks', 'saves', 'logs', 'crash-reports', 'launch-failures', 'config', 'server', 'game-processes', 'instance.json', 'options.txt'],
         }
       }
-      if (clean === 'mods' || clean === 'resourcepacks' || clean === 'shaderpacks') return (await resources(clean)).map(summarizeResource)
+      if (clean === 'mods' || clean === 'resourcepacks' || clean === 'shaderpacks') {
+        // Instances can hold hundreds of mods; sending them all would blow the
+        // context window, so only a page is returned and the rest is summarized.
+        const all = await resources(clean)
+        const offset = Number.isFinite(listOffset) ? Math.max(0, Math.trunc(listOffset as number)) : 0
+        const page = all.slice(offset, offset + RESOURCE_LIST_LIMIT)
+        return {
+          path: clean,
+          total: all.length,
+          offset,
+          limit: RESOURCE_LIST_LIMIT,
+          truncated: all.length > offset + page.length,
+          entries: page.map(summarizeResource),
+        }
+      }
       if (clean === 'saves') return (await savesService.watch(instancePath)).saves
       if (clean === 'logs') return logService.listLogs(instancePath)
       if (clean === 'crash-reports') return logService.listCrashReports(instancePath)
@@ -200,11 +217,11 @@ export function useAgentToolFactory() {
       {
         name: 'vfs_list',
         label: 'List instance files',
-        description: 'List a virtual directory for the explicitly selected instance.',
-        parameters: Type.Object({ path: Type.Optional(Type.String()) }),
+        description: `List a virtual directory for the explicitly selected instance. Resource directories (mods, resourcepacks, shaderpacks) return at most ${RESOURCE_LIST_LIMIT} entries per call; use offset to page through the rest.`,
+        parameters: Type.Object({ path: Type.Optional(Type.String()), offset: Type.Optional(Type.Number()) }),
         executionMode: 'sequential',
         async execute(_id, args: any) {
-          return textResult(await list(String(args.path ?? '')))
+          return textResult(await list(String(args.path ?? ''), args.offset))
         },
       },
       {
@@ -678,13 +695,26 @@ export function useAgentToolFactory() {
       name: 'ui',
       label: 'Launcher UI',
       description: 'Navigate or inspect the XMCL user interface. The run instance and user cannot be changed.',
-      parameters: Type.Union([
-        Type.Object({ action: Type.Literal('navigate'), path: Type.String() }),
-        Type.Object({ action: Type.Literal('confirm'), message: Type.String(), destructive: Type.Optional(Type.Boolean()) }),
-        Type.Object({ action: Type.Literal('query_dom'), selector: Type.String(), limit: Type.Optional(Type.Number()) }),
-        Type.Object({ action: Type.Literal('get_computed_style'), selector: Type.String(), properties: Type.Optional(Type.Array(Type.String())) }),
-        Type.Object({ action: Type.Literal('get_dom_outline'), selector: Type.Optional(Type.String()), maxDepth: Type.Optional(Type.Number()) }),
-      ]),
+      parameters: actionObjectSchema(
+        ['navigate', 'confirm', 'query_dom', 'get_computed_style', 'get_dom_outline'],
+        {
+          path: { type: 'string', description: 'Route path. Required for navigate.' },
+          message: { type: 'string', description: 'Prompt text. Required for confirm.' },
+          destructive: { type: 'boolean', description: 'Mark a confirm as destructive.' },
+          selector: {
+            type: 'string',
+            description: 'CSS selector. Required for query_dom and get_computed_style; optional for get_dom_outline.',
+          },
+          limit: { type: 'number', description: 'Max elements for query_dom (1-50).' },
+          properties: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'CSS properties for get_computed_style.',
+          },
+          maxDepth: { type: 'number', description: 'Tree depth for get_dom_outline (1-8).' },
+        },
+        'Which UI operation to run.',
+      ),
       executionMode: 'sequential',
       async execute(_id, input, signal) {
         return textResult(await uiHandler(input as any, signal))
@@ -722,11 +752,23 @@ export function useCssAgentToolFactory() {
     name: 'ui',
     label: 'Launcher UI',
     description: 'Inspect the XMCL user interface for CSS selectors and computed styles.',
-    parameters: Type.Union([
-      Type.Object({ action: Type.Literal('query_dom'), selector: Type.String(), limit: Type.Optional(Type.Number()) }),
-      Type.Object({ action: Type.Literal('get_computed_style'), selector: Type.String(), properties: Type.Optional(Type.Array(Type.String())) }),
-      Type.Object({ action: Type.Literal('get_dom_outline'), selector: Type.Optional(Type.String()), maxDepth: Type.Optional(Type.Number()) }),
-    ]),
+    parameters: actionObjectSchema(
+      ['query_dom', 'get_computed_style', 'get_dom_outline'],
+      {
+        selector: {
+          type: 'string',
+          description: 'CSS selector. Required for query_dom and get_computed_style; optional for get_dom_outline.',
+        },
+        limit: { type: 'number', description: 'Max elements for query_dom (1-50).' },
+        properties: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'CSS properties for get_computed_style.',
+        },
+        maxDepth: { type: 'number', description: 'Tree depth for get_dom_outline (1-8).' },
+      },
+      'Which UI inspection to run.',
+    ),
     executionMode: 'parallel',
     async execute(_id, input, signal) {
       return textResult(await uiHandler(input as any, signal))

--- a/xmcl-keystone-ui/src/composables/agent/ui.test.ts
+++ b/xmcl-keystone-ui/src/composables/agent/ui.test.ts
@@ -50,4 +50,25 @@ describe('Agent UI handler', () => {
     }, controller.signal)).resolves.toBe(true)
     expect(confirm).toHaveBeenCalledWith(expect.objectContaining({ title: 'Install mod' }), controller.signal)
   })
+
+  // The wire schema is a flat object with every field optional (so strict
+  // providers accept it), so the handler is the only thing enforcing that a
+  // given action actually got the fields it needs.
+  test('rejects an action that is missing its required field', async () => {
+    const { handle } = handler([])
+    await expect(handle({ action: 'navigate' } as any)).rejects.toThrow('"path" is required')
+    await expect(handle({ action: 'query_dom' } as any)).rejects.toThrow('"selector" is required')
+    await expect(handle({ action: 'get_computed_style' } as any)).rejects.toThrow('"selector" is required')
+    await expect(handle({ action: 'select_account' } as any)).rejects.toThrow('"id" is required')
+  })
+
+  test('treats a blank required field as missing', async () => {
+    const { handle } = handler([])
+    await expect(handle({ action: 'navigate', path: '   ' })).rejects.toThrow('"path" is required')
+  })
+
+  test('rejects an unknown action instead of silently outlining the DOM', async () => {
+    const { handle } = handler([])
+    await expect(handle({ action: 'drop_database' } as any)).rejects.toThrow('Unknown ui action')
+  })
 })

--- a/xmcl-keystone-ui/src/composables/agent/ui.ts
+++ b/xmcl-keystone-ui/src/composables/agent/ui.ts
@@ -40,38 +40,51 @@ export interface AgentUiContext {
 
 export function createAgentUiHandler(context: AgentUiContext) {
   return async (input: AgentUiAction, signal?: AbortSignal): Promise<unknown> => {
+    // The wire schema is a flat object (see actionObjectSchema), so per-action
+    // required fields are not enforced by the provider and must be checked here.
+    const required = (value: string | undefined, field: string) => {
+      const trimmed = typeof value === 'string' ? value.trim() : ''
+      if (!trimmed) throw new Error(`"${field}" is required for the "${input.action}" action`)
+      return trimmed
+    }
     if (input.action === 'navigate') {
-      await context.router.push(input.path)
-      return { ok: true, path: input.path }
+      const path = required(input.path, 'path')
+      await context.router.push(path)
+      return { ok: true, path }
     }
     if (input.action === 'select_instance') {
-      const exact = context.instances.value.find(instance => instance.path === input.path)
-      const named = context.instances.value.filter(instance => instance.name === input.path)
+      const target = required(input.path, 'path')
+      const exact = context.instances.value.find(instance => instance.path === target)
+      const named = context.instances.value.filter(instance => instance.name === target)
       const instance = exact ?? (named.length === 1 ? named[0] : undefined)
       if (!instance) {
         throw new Error(named.length > 1
-          ? `Instance name is ambiguous; use an exact path: ${input.path}`
-          : `Unknown instance path or name: ${input.path}`)
+          ? `Instance name is ambiguous; use an exact path: ${target}`
+          : `Unknown instance path or name: ${target}`)
       }
       context.selectedInstance.value = instance.path
       return { ok: true, path: instance.path }
     }
     if (input.action === 'select_account') {
-      context.selectAccount(input.id)
-      return { ok: true, id: input.id }
+      const id = required(input.id, 'id')
+      context.selectAccount(id)
+      return { ok: true, id }
     }
     if (input.action === 'confirm') {
+      required(input.message, 'message')
       if (context.confirm) return context.confirm(input, signal)
       return window.confirm(input.message)
     }
     if (input.action === 'query_dom') {
-      const nodes = Array.from(document.querySelectorAll(input.selector))
+      const selector = required(input.selector, 'selector')
+      const nodes = Array.from(document.querySelectorAll(selector))
       const limit = Math.min(Math.max(1, input.limit ?? 10), 50)
       return { total: nodes.length, elements: nodes.slice(0, limit).map(describeElement) }
     }
     if (input.action === 'get_computed_style') {
-      const element = document.querySelector(input.selector)
-      if (!element) return { error: `no element matches: ${input.selector}` }
+      const target = required(input.selector, 'selector')
+      const element = document.querySelector(target)
+      if (!element) return { error: `no element matches: ${target}` }
       const style = window.getComputedStyle(element)
       const properties = input.properties?.length
         ? input.properties
@@ -80,6 +93,9 @@ export function createAgentUiHandler(context: AgentUiContext) {
         element: nodeLabel(element),
         styles: Object.fromEntries(properties.map(property => [property, style.getPropertyValue(property)])),
       }
+    }
+    if (input.action !== 'get_dom_outline') {
+      throw new Error(`Unknown ui action: ${(input as { action: string }).action}`)
     }
     const selector = input.selector || '.v-application'
     const root = document.querySelector(selector)

--- a/xmcl-keystone-ui/src/views/AppAgentChat.vue
+++ b/xmcl-keystone-ui/src/views/AppAgentChat.vue
@@ -77,7 +77,7 @@
         class="flex-1 min-h-0 overflow-y-auto overflow-x-hidden px-3 py-2 space-y-2"
       >
         <div
-          v-if="transcriptItems.length === 0"
+          v-if="transcriptItems.length === 0 && !displayError"
           class="h-full flex items-center justify-center text-center text-medium-emphasis px-6"
         >
           <div class="w-full max-w-sm">
@@ -140,6 +140,22 @@
           <v-progress-circular indeterminate size="14" width="2" />
           <span>{{ liveStatus }}</span>
         </div>
+
+        <!-- Failures belong in the transcript: they are part of the conversation
+             and are easy to miss tucked into the footer. -->
+        <div v-if="displayError && !running" data-testid="agent-error" class="flex justify-start">
+          <div class="agent-error">
+            <v-icon size="small" color="error" class="agent-error__icon">error_outline</v-icon>
+            <div class="min-w-0 flex-1">
+              <div class="agent-error__title">
+                {{ t('agent.errorTitle') }}
+              </div>
+              <div class="agent-error__body">
+                {{ displayError }}
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
 
       <!-- Input -->
@@ -182,8 +198,6 @@
         <div class="mt-2 text-xs text-medium-emphasis flex items-center gap-2">
           <kbd>Ctrl</kbd><kbd>Shift</kbd><kbd>A</kbd>
           <span>{{ t('agent.toggleHint') }}</span>
-          <v-spacer />
-          <span v-if="displayError" class="text-error truncate" :title="displayError">{{ displayError }}</span>
         </div>
       </div>
     </v-card>
@@ -407,8 +421,9 @@ function openSetupDoc() {
   window.open(setupDocUrl.value, 'browser')
 }
 
-// Auto-scroll on new messages / events.
-watch([transcriptItems, events], async () => {
+// Auto-scroll on new messages / events. `displayError` is included so a failure
+// rendered at the end of the transcript scrolls into view like any other message.
+watch([transcriptItems, events, displayError], async () => {
   await nextTick()
   const el = scrollEl.value
   if (el) el.scrollTop = el.scrollHeight
@@ -579,6 +594,36 @@ watch(isShown, async (v) => {
   width: 78%;
   max-width: 640px;
   min-width: 0;
+}
+.agent-error {
+  display: flex;
+  max-width: 85%;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 9px;
+  padding: 9px 13px;
+  border-radius: 12px;
+  border: 1px solid rgba(var(--v-theme-error), 0.5);
+  background: rgba(var(--v-theme-error), 0.12);
+}
+.agent-error__icon {
+  margin-top: 1px;
+  flex-shrink: 0;
+}
+.agent-error__title {
+  color: rgb(var(--v-theme-error));
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.45;
+}
+.agent-error__body {
+  margin-top: 2px;
+  color: rgba(var(--v-theme-on-surface), 0.8);
+  font-size: 12.5px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow-wrap: anywhere;
 }
 .agent-confirm {
   overflow: hidden;

--- a/xmcl-keystone-ui/src/views/AppCommandPalette.vue
+++ b/xmcl-keystone-ui/src/views/AppCommandPalette.vue
@@ -350,32 +350,6 @@
       <v-divider />
 
       <div class="palette-footer px-4 py-2 text-medium-emphasis text-caption flex items-center gap-2 flex-wrap">
-<<<<<<< HEAD
-        <span class="palette-footer__group">
-          <kbd>↑</kbd><kbd>↓</kbd>
-          <span class="palette-footer__label">{{ t('commandPalette.hintNavigate') }}</span>
-        </span>
-        <span class="palette-footer__group">
-          <kbd>Enter</kbd>
-          <span class="palette-footer__label">{{ t('commandPalette.hintInvoke') }}</span>
-        </span>
-        <span v-if="pendingInstanceAction || pendingInstancePath || pendingSettingId" class="palette-footer__group">
-          <kbd>←</kbd>
-          <span class="palette-footer__label">{{ t('commandPalette.hintBack') }}</span>
-        </span>
-        <span v-else-if="isSelectedCommandMultiStep" class="palette-footer__group">
-          <kbd>→</kbd>
-          <span class="palette-footer__label">{{ t('commandPalette.hintEnter') }}</span>
-        </span>
-        <span class="palette-footer__group">
-          <kbd>Esc</kbd>
-          <span class="palette-footer__label">{{ t('commandPalette.hintClose') }}</span>
-        </span>
-        <v-spacer />
-        <span class="palette-footer__group">
-          <kbd>Ctrl</kbd><kbd>K</kbd>
-        </span>
-=======
         <template v-if="gamepadActive">
           <span class="palette-footer__group">
             <kbd class="gp-btn__key">D-Pad</kbd>
@@ -385,7 +359,7 @@
             <kbd class="gp-btn__key">{{ buttonA }}</kbd>
             <span class="palette-footer__label">{{ t('commandPalette.hintInvoke') }}</span>
           </span>
-          <span v-if="pendingInstanceAction || pendingSettingId" class="palette-footer__group">
+          <span v-if="pendingInstanceAction || pendingInstancePath || pendingSettingId" class="palette-footer__group">
             <kbd class="gp-btn__key">D-Pad ←</kbd>
             <span class="palette-footer__label">{{ t('commandPalette.hintBack') }}</span>
           </span>
@@ -411,7 +385,7 @@
             <kbd>Enter</kbd>
             <span class="palette-footer__label">{{ t('commandPalette.hintInvoke') }}</span>
           </span>
-          <span v-if="pendingInstanceAction || pendingSettingId" class="palette-footer__group">
+          <span v-if="pendingInstanceAction || pendingInstancePath || pendingSettingId" class="palette-footer__group">
             <kbd>←</kbd>
             <span class="palette-footer__label">{{ t('commandPalette.hintBack') }}</span>
           </span>
@@ -428,7 +402,6 @@
             <kbd>Ctrl</kbd><kbd>K</kbd>
           </span>
         </template>
->>>>>>> origin/master
       </div>
     </v-card>
   </v-dialog>

--- a/xmcl-keystone-ui/src/views/SettingGeneral.vue
+++ b/xmcl-keystone-ui/src/views/SettingGeneral.vue
@@ -99,10 +99,26 @@
 
     <template v-if="developerMode">
       <v-divider class="my-3" />
+
+      <SettingItemSelect
+        :model-value="agentProviderId"
+        icon="cloud"
+        :title="t('setting.aiAgentProvider')"
+        :description="t('setting.aiAgentProviderDescription')"
+        :items="agentProviderItems"
+        @update:model-value="selectAgentProvider($event)"
+      />
+
+      <v-divider class="my-3" />
+
       <SettingItem id="agent-settings" :title="t('setting.aiAgentApiKey')" :description="t('setting.aiAgentApiKeyDescription')">
         <template #title>
           <v-icon start size="small" color="primary">key</v-icon>
           {{ t('setting.aiAgentApiKey') }}
+          <v-chip v-if="agentConfigured" size="x-small" color="success" class="ml-2">
+            <v-icon start size="x-small">check_circle</v-icon>
+            {{ t('setting.aiAgentApiKeySaved') }}
+          </v-chip>
         </template>
         <template #action>
           <v-text-field
@@ -113,13 +129,30 @@
             density="compact"
             class="setting-item-input"
             hide-details
-            clearable
-            :placeholder="agentConfigured ? '••••••••' : ''"
+            :placeholder="agentConfigured ? t('setting.aiAgentApiKeyStored') : t('setting.aiAgentApiKeyEmpty')"
+            :loading="clearingAgentKey"
             @update:model-value="updateAgentApiKey($event ?? '')"
           >
             <template #append-inner>
-              <v-btn icon variant="text" size="small" @click="showAgentApiKey = !showAgentApiKey">
+              <!-- The stored key is never read back, so the toggle only has
+                   something to reveal while the user is typing a new one. -->
+              <v-btn v-if="agentApiKey" icon variant="text" size="small" @click="showAgentApiKey = !showAgentApiKey">
                 <v-icon>{{ showAgentApiKey ? 'visibility_off' : 'visibility' }}</v-icon>
+              </v-btn>
+              <!-- Stands in for the built-in `clearable` affordance, which only
+                   appears while the field holds text and so could never reach a
+                   saved key (the field is empty once the key is stored). -->
+              <v-btn
+                v-if="agentApiKey || agentConfigured"
+                data-testid="agent-api-key-clear"
+                icon
+                variant="text"
+                size="small"
+                :disabled="clearingAgentKey"
+                :title="t('setting.aiAgentApiKeyClear')"
+                @click="onClearAgentApiKey"
+              >
+                <v-icon>close</v-icon>
               </v-btn>
             </template>
           </v-text-field>
@@ -176,6 +209,7 @@ import { kCriticalStatus } from '@/composables/criticalStatus'
 import { useGetDataDirErrorText } from '@/composables/dataRootErrors'
 import { kEnvironment } from '@/composables/environment'
 import { injection } from '@/util/inject'
+import { CUSTOM_AGENT_PROVIDER_ID } from '@xmcl/runtime-api'
 import { useDialog } from '../composables/dialog'
 import { useAgentSettings } from '../composables/agent/settings'
 import { useGameDirectory, useSettings } from '../composables/setting'
@@ -215,16 +249,37 @@ const {
   endpoint: agentEndpoint,
   model: agentModel,
   configured: agentConfigured,
-  setApiKey: setAgentApiKey,
+  updateApiKey: updateAgentApiKey,
+  clearApiKey: clearAgentApiKey,
+  providers: agentProviders,
+  providerId: agentProviderId,
+  selectProvider: selectAgentProvider,
 } = useAgentSettings()
+const agentProviderItems = computed(() => {
+  const items = agentProviders.map(({ id, name }) => ({ text: name, value: id }))
+  // The custom entry is only offered when the endpoint no longer matches a preset,
+  // so it acts as a read-only indicator rather than a selectable option.
+  if (agentProviderId.value === CUSTOM_AGENT_PROVIDER_ID) {
+    items.push({ text: t('setting.aiAgentProviderCustom'), value: CUSTOM_AGENT_PROVIDER_ID })
+  }
+  return items
+})
 const showAgentApiKey = ref(false)
-let agentApiKeyTimer: ReturnType<typeof setTimeout> | undefined
-function updateAgentApiKey(value: string) {
-  agentApiKey.value = value
-  if (agentApiKeyTimer) clearTimeout(agentApiKeyTimer)
-  agentApiKeyTimer = setTimeout(async () => {
-    await setAgentApiKey(value)
-  }, 500)
+// Re-hide the key when the field empties (provider switch, or the user cleared it)
+// so the next key typed does not start out visible.
+watch(agentApiKey, value => {
+  if (!value) showAgentApiKey.value = false
+})
+
+const clearingAgentKey = ref(false)
+/** Clear the field and forget whatever key is stored for the current provider. */
+async function onClearAgentApiKey() {
+  clearingAgentKey.value = true
+  try {
+    await clearAgentApiKey()
+  } finally {
+    clearingAgentKey.value = false
+  }
 }
 
 const { show } = useDialog('migration')

--- a/xmcl-keystone-ui/src/views/SettingGeneral.vue
+++ b/xmcl-keystone-ui/src/views/SettingGeneral.vue
@@ -115,7 +115,10 @@
         <template #title>
           <v-icon start size="small" color="primary">key</v-icon>
           {{ t('setting.aiAgentApiKey') }}
-          <v-chip v-if="agentConfigured" size="x-small" color="success" class="ml-2">
+          <v-chip v-if="agentKeyless" size="x-small" color="info" class="ml-2">
+            {{ t('setting.aiAgentApiKeyNotNeeded') }}
+          </v-chip>
+          <v-chip v-else-if="agentConfigured" size="x-small" color="success" class="ml-2">
             <v-icon start size="x-small">check_circle</v-icon>
             {{ t('setting.aiAgentApiKeySaved') }}
           </v-chip>
@@ -129,7 +132,9 @@
             density="compact"
             class="setting-item-input"
             hide-details
-            :placeholder="agentConfigured ? t('setting.aiAgentApiKeyStored') : t('setting.aiAgentApiKeyEmpty')"
+            :placeholder="agentKeyless
+              ? t('setting.aiAgentApiKeyNotNeededHint')
+              : agentConfigured ? t('setting.aiAgentApiKeyStored') : t('setting.aiAgentApiKeyEmpty')"
             :loading="clearingAgentKey"
             @update:model-value="updateAgentApiKey($event ?? '')"
           >
@@ -143,7 +148,7 @@
                    appears while the field holds text and so could never reach a
                    saved key (the field is empty once the key is stored). -->
               <v-btn
-                v-if="agentApiKey || agentConfigured"
+                v-if="agentApiKey || (agentConfigured && !agentKeyless)"
                 data-testid="agent-api-key-clear"
                 icon
                 variant="text"
@@ -253,6 +258,7 @@ const {
   clearApiKey: clearAgentApiKey,
   providers: agentProviders,
   providerId: agentProviderId,
+  keyless: agentKeyless,
   selectProvider: selectAgentProvider,
 } = useAgentSettings()
 const agentProviderItems = computed(() => {

--- a/xmcl-runtime-api/src/services/AgentService.test.ts
+++ b/xmcl-runtime-api/src/services/AgentService.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from 'vitest'
+import {
+  AGENT_PROVIDER_PRESETS,
+  CUSTOM_AGENT_PROVIDER_ID,
+  DEFAULT_AGENT_ENDPOINT,
+  DEFAULT_AGENT_MODEL,
+  getAgentProviderPreset,
+  normalizeAgentBaseUrl,
+  resolveAgentProviderId,
+  resolveAgentSecretAccount,
+} from './AgentService'
+
+describe('agent provider presets', () => {
+  test('keeps agnes as the default so existing users see no change', () => {
+    expect(DEFAULT_AGENT_ENDPOINT).toBe('https://apihub.agnes-ai.com/v1/chat/completions')
+    expect(DEFAULT_AGENT_MODEL).toBe('agnes-2.0-flash')
+    expect(AGENT_PROVIDER_PRESETS[0].id).toBe('agnes')
+  })
+
+  test('preset ids and hosts are unique', () => {
+    expect(new Set(AGENT_PROVIDER_PRESETS.map(p => p.id)).size).toBe(AGENT_PROVIDER_PRESETS.length)
+    expect(new Set(AGENT_PROVIDER_PRESETS.map(p => p.host)).size).toBe(AGENT_PROVIDER_PRESETS.length)
+  })
+
+  test('every preset endpoint resolves back to its own id', () => {
+    for (const preset of AGENT_PROVIDER_PRESETS) {
+      expect(resolveAgentProviderId(preset.endpoint)).toBe(preset.id)
+      expect(getAgentProviderPreset(preset.id)).toBe(preset)
+    }
+  })
+
+  test('unknown endpoints resolve to the custom provider', () => {
+    expect(resolveAgentProviderId('https://example.com/v1/chat/completions')).toBe(CUSTOM_AGENT_PROVIDER_ID)
+    expect(getAgentProviderPreset(CUSTOM_AGENT_PROVIDER_ID)).toBeUndefined()
+  })
+
+  test('base url strips the chat completions suffix', () => {
+    for (const preset of AGENT_PROVIDER_PRESETS) {
+      expect(normalizeAgentBaseUrl(preset.endpoint).endsWith('/chat/completions')).toBe(false)
+    }
+    expect(normalizeAgentBaseUrl('https://api.openai.com/v1/chat/completions/')).toBe('https://api.openai.com/v1')
+  })
+})
+
+describe('resolveAgentSecretAccount', () => {
+  test('gives every preset its own account', () => {
+    const accounts = AGENT_PROVIDER_PRESETS.map(p => resolveAgentSecretAccount(p.endpoint))
+    expect(new Set(accounts).size).toBe(AGENT_PROVIDER_PRESETS.length)
+    expect(resolveAgentSecretAccount(DEFAULT_AGENT_ENDPOINT)).toBe('agnes')
+  })
+
+  test('separates distinct custom hosts so keys do not leak between them', () => {
+    const a = resolveAgentSecretAccount('https://a.example.com/v1/chat/completions')
+    const b = resolveAgentSecretAccount('https://b.example.com/v1/chat/completions')
+    expect(a).not.toBe(b)
+    expect(a.startsWith(CUSTOM_AGENT_PROVIDER_ID)).toBe(true)
+  })
+
+  test('is stable across paths and casing on the same custom host', () => {
+    expect(resolveAgentSecretAccount('https://A.Example.com/v1/chat/completions'))
+      .toBe(resolveAgentSecretAccount('https://a.example.com/v2/chat/completions'))
+  })
+
+  test('does not throw on an unparseable endpoint', () => {
+    expect(() => resolveAgentSecretAccount('not a url')).not.toThrow()
+  })
+})

--- a/xmcl-runtime-api/src/services/AgentService.test.ts
+++ b/xmcl-runtime-api/src/services/AgentService.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_AGENT_ENDPOINT,
   DEFAULT_AGENT_MODEL,
   getAgentProviderPreset,
+  isKeylessAgentEndpoint,
   normalizeAgentBaseUrl,
   resolveAgentProviderId,
   resolveAgentSecretAccount,
@@ -32,6 +33,35 @@ describe('agent provider presets', () => {
   test('unknown endpoints resolve to the custom provider', () => {
     expect(resolveAgentProviderId('https://example.com/v1/chat/completions')).toBe(CUSTOM_AGENT_PROVIDER_ID)
     expect(getAgentProviderPreset(CUSTOM_AGENT_PROVIDER_ID)).toBeUndefined()
+  })
+
+  // A substring host test would classify these as the preset they impersonate,
+  // and the stored API key is keyed off that id -- so the user's real key would
+  // be sent to an unrelated host.
+  test('a lookalike host is never matched to a preset', () => {
+    for (const endpoint of [
+      'https://api.openai.com.attacker.example/v1/chat/completions',
+      'https://evil.example/?x=api.openai.com',
+      'https://notapi.openai.com.co/v1/chat/completions',
+      'https://api.deepseek.com.example.net/v1/chat/completions',
+    ]) {
+      expect(resolveAgentProviderId(endpoint)).toBe(CUSTOM_AGENT_PROVIDER_ID)
+      expect(resolveAgentSecretAccount(endpoint)).not.toBe('openai')
+      expect(resolveAgentSecretAccount(endpoint)).not.toBe('deepseek')
+    }
+  })
+
+  test('a preset host still matches regardless of scheme, case or path', () => {
+    expect(resolveAgentProviderId('https://API.OpenAI.com/v1/chat/completions')).toBe('openai')
+    expect(resolveAgentProviderId('https://api.openai.com/v2/chat/completions')).toBe('openai')
+  })
+
+  test('only the keyless preset is marked keyless', () => {
+    expect(isKeylessAgentEndpoint('http://localhost:11434/v1/chat/completions')).toBe(true)
+    expect(isKeylessAgentEndpoint(DEFAULT_AGENT_ENDPOINT)).toBe(false)
+    expect(isKeylessAgentEndpoint('https://api.openai.com/v1/chat/completions')).toBe(false)
+    // A remote lookalike must not inherit the local provider's keyless status.
+    expect(isKeylessAgentEndpoint('https://localhost:11434.attacker.example/v1')).toBe(false)
   })
 
   test('base url strips the chat completions suffix', () => {

--- a/xmcl-runtime-api/src/services/AgentService.ts
+++ b/xmcl-runtime-api/src/services/AgentService.ts
@@ -1,22 +1,153 @@
 import type { ServiceKey } from './Service'
 
-/** Default OpenAI-compatible agent endpoint. The API key is stored separately. */
-export const DEFAULT_AGENT_ENDPOINT = 'https://apihub.agnes-ai.com/v1/chat/completions'
-/** Default agent model identifier. */
-export const DEFAULT_AGENT_MODEL = 'agnes-2.0-flash'
 /** Conservative context window assumed for OpenAI-compatible agent models. */
 export const AGENT_MODEL_CONTEXT_WINDOW = 128_000
 /** Conservative max output tokens assumed for OpenAI-compatible agent models. */
 export const AGENT_MODEL_MAX_TOKENS = 8_192
+
+/** Provider id used when the endpoint does not match any known preset. */
+export const CUSTOM_AGENT_PROVIDER_ID = 'custom-openai'
+
+/**
+ * A selectable OpenAI-completions compatible provider. Providers requiring OAuth
+ * are intentionally not modelled here: every preset authenticates with an API key.
+ */
+export interface AgentProviderPreset {
+  id: string
+  /** Display name shown in the provider dropdown. */
+  name: string
+  /** Chat completions endpoint pre-filled when the preset is selected. */
+  endpoint: string
+  /** Model pre-filled when the preset is selected. */
+  defaultModel: string
+  /** Host fragment used to map an arbitrary endpoint back to this preset. */
+  host: string
+  /** Where the user can obtain an API key. */
+  apiKeyUrl?: string
+}
+
+/**
+ * Built-in providers. The first entry is the default so the out-of-the-box
+ * behavior stays unchanged.
+ *
+ * Each `defaultModel` is the current-generation, best value-for-money model of
+ * that provider (the cheap/fast tier, not the flagship), verified against the
+ * provider's own docs in July 2026. Providers retire model ids fairly quickly,
+ * so re-check these against the official model list when touching this table.
+ */
+export const AGENT_PROVIDER_PRESETS: readonly AgentProviderPreset[] = Object.freeze([
+  {
+    id: 'agnes',
+    name: 'Agnes',
+    endpoint: 'https://apihub.agnes-ai.com/v1/chat/completions',
+    defaultModel: 'agnes-2.0-flash',
+    host: 'apihub.agnes-ai.com',
+  },
+  {
+    id: 'openai',
+    name: 'OpenAI',
+    endpoint: 'https://api.openai.com/v1/chat/completions',
+    // Cheapest GPT-5.6 tier ($1/$6 per 1M), 1M context.
+    defaultModel: 'gpt-5.6-luna',
+    host: 'api.openai.com',
+    apiKeyUrl: 'https://platform.openai.com/api-keys',
+  },
+  {
+    id: 'deepseek',
+    name: 'DeepSeek',
+    endpoint: 'https://api.deepseek.com/v1/chat/completions',
+    // `deepseek-chat` was retired 2026-07-24; V4-Flash is the value tier.
+    defaultModel: 'deepseek-v4-flash',
+    host: 'api.deepseek.com',
+    apiKeyUrl: 'https://platform.deepseek.com/api_keys',
+  },
+  {
+    id: 'openrouter',
+    name: 'OpenRouter',
+    endpoint: 'https://openrouter.ai/api/v1/chat/completions',
+    defaultModel: 'openai/gpt-5.6-luna',
+    host: 'openrouter.ai',
+    apiKeyUrl: 'https://openrouter.ai/keys',
+  },
+  {
+    id: 'siliconflow',
+    name: 'SiliconFlow',
+    endpoint: 'https://api.siliconflow.cn/v1/chat/completions',
+    // Mid-size open model with tool calling; far cheaper than the 700B+ flagships.
+    defaultModel: 'Qwen/Qwen3.6-27B',
+    host: 'api.siliconflow.cn',
+    apiKeyUrl: 'https://cloud.siliconflow.cn/account/ak',
+  },
+  {
+    id: 'moonshot',
+    name: 'Moonshot',
+    endpoint: 'https://api.moonshot.cn/v1/chat/completions',
+    // The moonshot-v1 series sunsets 2026-08-31; K3 is the current generation.
+    defaultModel: 'kimi-k3',
+    host: 'api.moonshot.cn',
+    apiKeyUrl: 'https://platform.moonshot.cn/console/api-keys',
+  },
+  {
+    id: 'zhipu',
+    name: 'Zhipu GLM',
+    endpoint: 'https://open.bigmodel.cn/api/paas/v4/chat/completions',
+    // Current flagship generation; GLM-4.x is superseded and partly retired.
+    defaultModel: 'glm-5.2',
+    host: 'open.bigmodel.cn',
+    apiKeyUrl: 'https://open.bigmodel.cn/usercenter/apikeys',
+  },
+  {
+    id: 'ollama',
+    name: 'Ollama (local)',
+    endpoint: 'http://localhost:11434/v1/chat/completions',
+    // Tool-capable coding model that fits a 24-32GB machine. Local models are
+    // hardware-bound, so this is a starting point users are expected to change.
+    defaultModel: 'qwen3-coder:30b',
+    host: 'localhost:11434',
+  },
+])
+
+/** Default OpenAI-compatible provider preset. */
+export const DEFAULT_AGENT_PROVIDER = AGENT_PROVIDER_PRESETS[0]
+
+/** Default OpenAI-compatible agent endpoint. The API key is stored separately. */
+export const DEFAULT_AGENT_ENDPOINT = DEFAULT_AGENT_PROVIDER.endpoint
+/** Default agent model identifier. */
+export const DEFAULT_AGENT_MODEL = DEFAULT_AGENT_PROVIDER.defaultModel
+
+export function getAgentProviderPreset(id: string) {
+  return AGENT_PROVIDER_PRESETS.find(preset => preset.id === id)
+}
 
 /** Strip the trailing `/chat/completions` and any trailing slashes to derive a base URL. */
 export function normalizeAgentBaseUrl(endpoint: string) {
   return endpoint.trim().replace(/\/chat\/completions\/?$/i, '').replace(/\/+$/, '')
 }
 
-/** Derive a stable provider id from the configured endpoint. */
+/**
+ * Derive a stable provider id from the configured endpoint. Endpoints that do not
+ * belong to a known preset are reported as a generic custom OpenAI provider.
+ */
 export function resolveAgentProviderId(endpoint: string) {
-  return endpoint.includes('apihub.agnes-ai.com') ? 'agnes' : 'custom-openai'
+  return AGENT_PROVIDER_PRESETS.find(preset => endpoint.includes(preset.host))?.id ?? CUSTOM_AGENT_PROVIDER_ID
+}
+
+/**
+ * Secret-storage account under which the API key for `endpoint` is kept, so each
+ * provider keeps its own key and switching providers does not require re-entering
+ * one. Custom endpoints are additionally keyed by host, since two unrelated
+ * self-hosted endpoints must not share a key.
+ */
+export function resolveAgentSecretAccount(endpoint: string) {
+  const id = resolveAgentProviderId(endpoint)
+  if (id !== CUSTOM_AGENT_PROVIDER_ID) return id
+  let host = ''
+  try {
+    host = new URL(endpoint.trim()).host.toLowerCase()
+  } catch {
+    host = normalizeAgentBaseUrl(endpoint).toLowerCase()
+  }
+  return host ? `${id}@${host}` : id
 }
 
 export type AgentId = 'launcher' | 'css'

--- a/xmcl-runtime-api/src/services/AgentService.ts
+++ b/xmcl-runtime-api/src/services/AgentService.ts
@@ -22,6 +22,11 @@ export interface AgentProviderPreset {
   defaultModel: string
   /** Host fragment used to map an arbitrary endpoint back to this preset. */
   host: string
+  /**
+   * Set for providers that need no credentials (a local server, say), so the
+   * agent is usable without the user inventing a placeholder key.
+   */
+  keyless?: boolean
   /** Where the user can obtain an API key. */
   apiKeyUrl?: string
 }
@@ -104,6 +109,7 @@ export const AGENT_PROVIDER_PRESETS: readonly AgentProviderPreset[] = Object.fre
     // hardware-bound, so this is a starting point users are expected to change.
     defaultModel: 'qwen3-coder:30b',
     host: 'localhost:11434',
+    keyless: true,
   },
 ])
 
@@ -125,11 +131,29 @@ export function normalizeAgentBaseUrl(endpoint: string) {
 }
 
 /**
+ * The `host` (hostname plus any explicit port) of an endpoint, lowercased.
+ * Returns an empty string when the endpoint is not a parseable URL.
+ */
+function agentEndpointHost(endpoint: string) {
+  try {
+    return new URL(endpoint.trim()).host.toLowerCase()
+  } catch {
+    return ''
+  }
+}
+
+/**
  * Derive a stable provider id from the configured endpoint. Endpoints that do not
  * belong to a known preset are reported as a generic custom OpenAI provider.
+ *
+ * The host must match a preset exactly. A substring test would treat
+ * `api.openai.com.example.net` as OpenAI, and since the stored API key is keyed
+ * off this id, that would hand the user's real OpenAI key to an unrelated host.
  */
 export function resolveAgentProviderId(endpoint: string) {
-  return AGENT_PROVIDER_PRESETS.find(preset => endpoint.includes(preset.host))?.id ?? CUSTOM_AGENT_PROVIDER_ID
+  const host = agentEndpointHost(endpoint)
+  if (!host) return CUSTOM_AGENT_PROVIDER_ID
+  return AGENT_PROVIDER_PRESETS.find(preset => preset.host.toLowerCase() === host)?.id ?? CUSTOM_AGENT_PROVIDER_ID
 }
 
 /**
@@ -141,13 +165,13 @@ export function resolveAgentProviderId(endpoint: string) {
 export function resolveAgentSecretAccount(endpoint: string) {
   const id = resolveAgentProviderId(endpoint)
   if (id !== CUSTOM_AGENT_PROVIDER_ID) return id
-  let host = ''
-  try {
-    host = new URL(endpoint.trim()).host.toLowerCase()
-  } catch {
-    host = normalizeAgentBaseUrl(endpoint).toLowerCase()
-  }
+  const host = agentEndpointHost(endpoint) || normalizeAgentBaseUrl(endpoint).toLowerCase()
   return host ? `${id}@${host}` : id
+}
+
+/** Whether `endpoint` belongs to a preset that needs no API key. */
+export function isKeylessAgentEndpoint(endpoint: string) {
+  return !!getAgentProviderPreset(resolveAgentProviderId(endpoint))?.keyless
 }
 
 export type AgentId = 'launcher' | 'css'

--- a/xmcl-runtime/agent/AgentService.ts
+++ b/xmcl-runtime/agent/AgentService.ts
@@ -17,12 +17,10 @@ import { IS_DEV } from '~/constant'
 import { kSettings } from '~/settings'
 import { AbstractService, ExposeServiceKey } from '~/service'
 import { AgentBridge } from './AgentBridge'
+import { AgentApiKeyStore } from './apiKey'
 import { sanitizeAgentEndpoint, sanitizeAgentLog, summarizeAgentProviderPayload } from './debug'
 import { AgentHistoryStore } from './history'
 import { createAgentProvider } from './provider'
-
-const SECRET_SERVICE = 'xmcl/agent'
-const SECRET_ACCOUNT = 'default'
 
 function zeroUsage(): Usage {
   return {
@@ -44,6 +42,10 @@ export class AgentService extends AbstractService implements IAgentService {
   private history = new AgentHistoryStore(join(this.app.appDataPath, 'agent', 'history'), message => this.warn(message))
   private providerRequests = new Map<string, AbortController>()
   private agentLogger = this.app.getLogger('Agent', 'agent')
+  private apiKeys = new AgentApiKeyStore(this.app.secretStorage, async () => {
+    const settings = await this.app.registry.get(kSettings)
+    return settings.agentEndpoint || DEFAULT_AGENT_ENDPOINT
+  })
 
   constructor(@Inject(LauncherAppKey) app: LauncherApp) {
     super(app)
@@ -51,9 +53,10 @@ export class AgentService extends AbstractService implements IAgentService {
 
   async getProviderSettings() {
     const settings = await this.app.registry.get(kSettings)
-    const configured = !!await this.app.secretStorage.get(SECRET_SERVICE, SECRET_ACCOUNT)
+    const endpoint = settings.agentEndpoint || DEFAULT_AGENT_ENDPOINT
+    const configured = !!await this.apiKeys.get(endpoint)
     return {
-      endpoint: settings.agentEndpoint || DEFAULT_AGENT_ENDPOINT,
+      endpoint,
       model: settings.agentModel || DEFAULT_AGENT_MODEL,
       configured,
     }
@@ -61,19 +64,21 @@ export class AgentService extends AbstractService implements IAgentService {
 
   async setProviderSettings(input: UpdateAgentProviderSettings) {
     const settings = await this.app.registry.get(kSettings)
+    const endpoint = input.endpoint.trim() || DEFAULT_AGENT_ENDPOINT
     this.logAgent(`[provider.settings] ${sanitizeAgentLog({
-      endpoint: sanitizeAgentEndpoint(input.endpoint),
+      endpoint: sanitizeAgentEndpoint(endpoint),
       model: input.model,
       hasApiKey: input.apiKey !== undefined,
     })}`)
     // Persist the secret first: it is the only step that can fail (OS keychain
     // errors), and we must not leave the endpoint/model settings committed while
-    // the API key write was rejected.
+    // the API key write was rejected. The key is scoped to the endpoint being
+    // saved, so each provider keeps its own.
     if (input.apiKey !== undefined) {
-      await this.app.secretStorage.put(SECRET_SERVICE, SECRET_ACCOUNT, input.apiKey.trim())
+      await this.apiKeys.put(endpoint, input.apiKey)
     }
     settings.agentProviderSet({
-      endpoint: input.endpoint.trim() || DEFAULT_AGENT_ENDPOINT,
+      endpoint,
       model: input.model.trim() || DEFAULT_AGENT_MODEL,
     })
   }
@@ -135,7 +140,7 @@ export class AgentService extends AbstractService implements IAgentService {
       return
     }
 
-    const apiKey = await this.app.secretStorage.get(SECRET_SERVICE, SECRET_ACCOUNT)
+    const apiKey = await this.apiKeys.get(providerSettings.endpoint)
     const { api, model, providerId } = createAgentProvider(providerSettings.endpoint, providerSettings.model)
     const options = {
       ...request.options,

--- a/xmcl-runtime/agent/AgentService.ts
+++ b/xmcl-runtime/agent/AgentService.ts
@@ -3,6 +3,7 @@ import {
   AgentServiceKey,
   DEFAULT_AGENT_ENDPOINT,
   DEFAULT_AGENT_MODEL,
+  isKeylessAgentEndpoint,
   type AgentConversationKey,
   type AgentMessage,
   type AgentProviderStreamRequest,
@@ -54,7 +55,9 @@ export class AgentService extends AbstractService implements IAgentService {
   async getProviderSettings() {
     const settings = await this.app.registry.get(kSettings)
     const endpoint = settings.agentEndpoint || DEFAULT_AGENT_ENDPOINT
-    const configured = !!await this.apiKeys.get(endpoint)
+    // Keyless providers (a local Ollama, say) are ready as soon as they are
+    // selected; requiring a placeholder key would just be a hoop to jump through.
+    const configured = isKeylessAgentEndpoint(endpoint) || !!await this.apiKeys.get(endpoint)
     return {
       endpoint,
       model: settings.agentModel || DEFAULT_AGENT_MODEL,
@@ -140,7 +143,10 @@ export class AgentService extends AbstractService implements IAgentService {
       return
     }
 
+    // The OpenAI adapter expects a non-empty key even where the server ignores
+    // it, so keyless providers get a placeholder rather than an empty header.
     const apiKey = await this.apiKeys.get(providerSettings.endpoint)
+      ?? (isKeylessAgentEndpoint(providerSettings.endpoint) ? 'not-needed' : undefined)
     const { api, model, providerId } = createAgentProvider(providerSettings.endpoint, providerSettings.model)
     const options = {
       ...request.options,

--- a/xmcl-runtime/agent/apiKey.test.ts
+++ b/xmcl-runtime/agent/apiKey.test.ts
@@ -111,6 +111,22 @@ describe('AgentApiKeyStore', () => {
     await keys.put(DEFAULT_AGENT_ENDPOINT, 'fresh-key')
 
     expect(await keys.get(DEFAULT_AGENT_ENDPOINT)).toBe('fresh-key')
-    expect(await storage.get(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT)).toBe('legacy-key')
+  })
+
+  // If a previous migration wrote the per-provider key but failed to delete the
+  // legacy copy, that copy must not stay eligible: after a provider switch the
+  // new provider would be seen as its owner and inherit another service's key.
+  test('retires a superseded legacy key instead of leaving it migratable', async () => {
+    await storage.put(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT, 'legacy-key')
+    await storage.put(SECRET_SERVICE, 'agnes', 'agnes-key')
+    let configured = DEFAULT_AGENT_ENDPOINT
+    const keys = new AgentApiKeyStore(storage, async () => configured)
+
+    expect(await keys.get(DEFAULT_AGENT_ENDPOINT)).toBe('agnes-key')
+    expect(await storage.get(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT)).toBeUndefined()
+
+    // Switching providers must not resurrect the legacy key under the new one.
+    configured = OPENAI
+    expect(await keys.get(OPENAI)).toBeUndefined()
   })
 })

--- a/xmcl-runtime/agent/apiKey.test.ts
+++ b/xmcl-runtime/agent/apiKey.test.ts
@@ -1,0 +1,116 @@
+import { DEFAULT_AGENT_ENDPOINT } from '@xmcl/runtime-api'
+import { beforeEach, describe, expect, test } from 'vitest'
+import type { SecretStorage } from '~/app'
+import { AgentApiKeyStore, LEGACY_SECRET_ACCOUNT, SECRET_SERVICE } from './apiKey'
+
+const OPENAI = 'https://api.openai.com/v1/chat/completions'
+const CUSTOM = 'https://self.hosted.example/v1/chat/completions'
+
+class MemoryStorage implements SecretStorage {
+  entries = new Map<string, string>()
+
+  async get(service: string, account: string) {
+    return this.entries.get(`${service}@${account}`)
+  }
+
+  async put(service: string, account: string, value: string) {
+    const key = `${service}@${account}`
+    if (value) this.entries.set(key, value)
+    else this.entries.delete(key)
+  }
+}
+
+describe('AgentApiKeyStore', () => {
+  let storage: MemoryStorage
+
+  beforeEach(() => {
+    storage = new MemoryStorage()
+  })
+
+  const store = (configured = DEFAULT_AGENT_ENDPOINT) =>
+    new AgentApiKeyStore(storage, async () => configured)
+
+  test('keeps a separate key per provider', async () => {
+    const keys = store()
+    await keys.put(DEFAULT_AGENT_ENDPOINT, 'agnes-key')
+    await keys.put(OPENAI, 'openai-key')
+
+    expect(await keys.get(DEFAULT_AGENT_ENDPOINT)).toBe('agnes-key')
+    expect(await keys.get(OPENAI)).toBe('openai-key')
+  })
+
+  test('does not report a key for a provider that has none', async () => {
+    const keys = store()
+    await keys.put(OPENAI, 'openai-key')
+    expect(await keys.get(CUSTOM)).toBeUndefined()
+  })
+
+  test('trims the stored key and clears it when emptied', async () => {
+    const keys = store()
+    await keys.put(OPENAI, '  spaced  ')
+    expect(await keys.get(OPENAI)).toBe('spaced')
+
+    await keys.put(OPENAI, '')
+    expect(await keys.get(OPENAI)).toBeUndefined()
+  })
+
+  test('clearing removes the secret entirely rather than storing a blank', async () => {
+    const keys = store()
+    await keys.put(OPENAI, 'openai-key')
+    await keys.put(OPENAI, '')
+    // A blank entry left behind would still read as "configured" downstream.
+    expect(storage.entries.has(`${SECRET_SERVICE}@openai`)).toBe(false)
+  })
+
+  test('clearing one provider leaves the others untouched', async () => {
+    const keys = store()
+    await keys.put(DEFAULT_AGENT_ENDPOINT, 'agnes-key')
+    await keys.put(OPENAI, 'openai-key')
+
+    await keys.put(OPENAI, '')
+    expect(await keys.get(OPENAI)).toBeUndefined()
+    expect(await keys.get(DEFAULT_AGENT_ENDPOINT)).toBe('agnes-key')
+  })
+
+  test('a cleared provider can be configured again', async () => {
+    const keys = store()
+    await keys.put(OPENAI, 'first-key')
+    await keys.put(OPENAI, '')
+    await keys.put(OPENAI, 'second-key')
+    expect(await keys.get(OPENAI)).toBe('second-key')
+  })
+
+  test('migrates the legacy key to the endpoint configured at upgrade time', async () => {
+    await storage.put(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT, 'legacy-key')
+    const keys = store(DEFAULT_AGENT_ENDPOINT)
+
+    expect(await keys.get(DEFAULT_AGENT_ENDPOINT)).toBe('legacy-key')
+    // Legacy slot is cleared so the promotion happens exactly once.
+    expect(await storage.get(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT)).toBeUndefined()
+    expect(await keys.get(DEFAULT_AGENT_ENDPOINT)).toBe('legacy-key')
+  })
+
+  test('migrates to a custom endpoint when that was the configured one', async () => {
+    await storage.put(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT, 'legacy-key')
+    const keys = store(CUSTOM)
+    expect(await keys.get(CUSTOM)).toBe('legacy-key')
+  })
+
+  test('never hands the legacy key to a provider that did not own it', async () => {
+    await storage.put(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT, 'legacy-key')
+    const keys = store(DEFAULT_AGENT_ENDPOINT)
+
+    expect(await keys.get(OPENAI)).toBeUndefined()
+    // The legacy key must survive for its real owner.
+    expect(await keys.get(DEFAULT_AGENT_ENDPOINT)).toBe('legacy-key')
+  })
+
+  test('prefers an already per-provider key over the legacy one', async () => {
+    await storage.put(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT, 'legacy-key')
+    const keys = store(DEFAULT_AGENT_ENDPOINT)
+    await keys.put(DEFAULT_AGENT_ENDPOINT, 'fresh-key')
+
+    expect(await keys.get(DEFAULT_AGENT_ENDPOINT)).toBe('fresh-key')
+    expect(await storage.get(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT)).toBe('legacy-key')
+  })
+})

--- a/xmcl-runtime/agent/apiKey.ts
+++ b/xmcl-runtime/agent/apiKey.ts
@@ -1,0 +1,50 @@
+import { resolveAgentSecretAccount } from '@xmcl/runtime-api'
+import type { SecretStorage } from '~/app'
+
+export const SECRET_SERVICE = 'xmcl/agent'
+/**
+ * Account used before API keys were stored per provider. Its value is migrated to
+ * the owning provider's account on first read so existing users keep their key.
+ */
+export const LEGACY_SECRET_ACCOUNT = 'default'
+
+/**
+ * Per-provider API key store. Keys are scoped by provider so switching providers
+ * does not discard the previous provider's key, and one provider's key is never
+ * sent to another.
+ */
+export class AgentApiKeyStore {
+  /** Set once the legacy single-key secret has been promoted or found absent. */
+  private legacyMigrated = false
+
+  constructor(
+    private storage: SecretStorage,
+    /** Resolves the endpoint currently persisted in settings. */
+    private getConfiguredEndpoint: () => Promise<string>,
+  ) {}
+
+  async get(endpoint: string): Promise<string | undefined> {
+    const account = resolveAgentSecretAccount(endpoint)
+    const stored = await this.storage.get(SECRET_SERVICE, account)
+    if (stored || this.legacyMigrated) return stored
+
+    const legacy = await this.storage.get(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT)
+    if (!legacy) {
+      this.legacyMigrated = true
+      return stored
+    }
+    // The legacy key belongs to whichever provider was configured at upgrade time,
+    // i.e. the persisted endpoint. Handing it to whichever provider is asked for
+    // first would leak one provider's key to another.
+    if (account !== resolveAgentSecretAccount(await this.getConfiguredEndpoint())) return stored
+
+    await this.storage.put(SECRET_SERVICE, account, legacy)
+    await this.storage.put(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT, '')
+    this.legacyMigrated = true
+    return legacy
+  }
+
+  async put(endpoint: string, apiKey: string): Promise<void> {
+    await this.storage.put(SECRET_SERVICE, resolveAgentSecretAccount(endpoint), apiKey.trim())
+  }
+}

--- a/xmcl-runtime/agent/apiKey.ts
+++ b/xmcl-runtime/agent/apiKey.ts
@@ -26,10 +26,19 @@ export class AgentApiKeyStore {
   async get(endpoint: string): Promise<string | undefined> {
     const account = resolveAgentSecretAccount(endpoint)
     const stored = await this.storage.get(SECRET_SERVICE, account)
-    if (stored || this.legacyMigrated) return stored
+    if (this.legacyMigrated) return stored
 
     const legacy = await this.storage.get(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT)
     if (!legacy) {
+      this.legacyMigrated = true
+      return stored
+    }
+    // A provider-specific key already exists, so the legacy key has been
+    // superseded (or a previous migration deleted it only partially). Retire it
+    // now: leaving it in place would make it eligible to be copied to whichever
+    // provider is configured next, handing one service's key to another.
+    if (stored) {
+      await this.storage.put(SECRET_SERVICE, LEGACY_SECRET_ACCOUNT, '')
       this.legacyMigrated = true
       return stored
     }


### PR DESCRIPTION
## Summary

Lets users pick an OpenAI-compatible provider from a dropdown instead of hand-editing the endpoint URL. **Agnes remains the default, so out-of-the-box behavior is unchanged** — a test pins the default endpoint and model literals to keep it that way.

Built on top of #1618. All agent settings stay behind `developerMode`.

## Provider presets

Adds `AGENT_PROVIDER_PRESETS`: Agnes, OpenAI, DeepSeek, OpenRouter, SiliconFlow, Moonshot, Zhipu GLM, Ollama. Every preset authenticates with an API key — OAuth-only providers are deliberately out of scope.

Selecting a preset fills in the endpoint and model. A hand-typed model is never silently overwritten: the model only follows the preset when it is empty or still the previous preset's default. Endpoints that match no preset show as "Custom", which acts as an indicator rather than a selectable option.

Model ids are each provider's current-generation *value* tier (not the flagship), verified against provider docs. Worth noting the previous placeholder defaults had already gone stale — `deepseek-chat` was retired 2026-07-24 and the `moonshot-v1` series sunsets 2026-08-31.

## Per-provider API keys

Keys are now stored per provider, so switching providers no longer discards the previous key. `secretStorage` already had a `(service, account)` shape; the account was simply hardcoded to `default`.

The pre-existing single key is migrated on first read — and only to the provider that was configured at upgrade time (resolved from the *persisted* endpoint, not the built-in default, so users who had pointed the old field at a custom URL keep their key). One provider's key is never handed to another; there's a test for that specifically.

Custom endpoints are keyed by host, so two unrelated self-hosted endpoints don't share a key.

## UI fixes found while testing

- **Saved keys looked lost.** Keys are never read back into the renderer, so switching back to a configured provider showed an empty field whose only "saved" cue was a faint `••••••••` placeholder — indistinguishable from empty. Now there's an explicit *Saved* chip and descriptive placeholders for both states.
- **The reveal toggle had nothing to reveal.** Hidden unless the field actually holds text.
- **The clear button couldn't reach a saved key.** Vuetify's `clearable` only renders while the field has text — exactly not the case once a key is saved. Replaced with an equivalent button that appears when a key is stored *or* being typed, and which deletes the stored secret (verified to unlink rather than store a blank).
- A pending debounced key write is cancelled on provider switch and on clear, so a key typed moments earlier can't land under the wrong provider or resurrect a cleared one.

## `ui` tool schema fix

The `ui` tool declared `Type.Union([...])`, which serializes to a bare `anyOf` with **no top-level `type`**. DeepSeek rejects this outright:

```
400: Invalid schema for function 'ui': schema must be a JSON Schema of 'type: "object"', got 'type: null'
```

Agnes and OpenAI happen to tolerate it, so this was a latent bug that multi-provider support exposed rather than caused. The variants are flattened into a single object with an `action` enum.

Since the provider no longer enforces per-action required fields, that validation moved into the handler, which now throws a clear error naming the field and action. This also fixed a real pre-existing bug: the handler ended with an unconditional fallthrough to `get_dom_outline`, so any unrecognized action silently returned a DOM outline instead of erroring.

## Other

- **`vfs_list` caps resource listings at 10 entries** with an `offset` parameter for paging. Listing `mods` on a large instance previously returned every file, unbounded, which could blow the context window. Response now includes `total` / `offset` / `truncated`.
- **Agent errors moved into the transcript.** They were a `truncate`d single line in the footer — easy to miss, and long errors (like the DeepSeek one above) were unreadable without hovering for the `title`. Now rendered as an error card at the end of the conversation, full text, scrolled into view.

## Test plan

- `pnpm run check` clean across all four projects
- `pnpm exec vitest run` — 1225 passed / 25 skipped
- New tests: provider preset resolution and secret-account derivation; key store isolation, migration ownership, and clearing semantics; `actionObjectSchema` shape (asserts `type: object` and no `anyOf` — the check that would have caught the DeepSeek bug); UI handler required-field and unknown-action validation
- Manually verified in a dev build against a real DeepSeek key: provider switching, key persistence across switches, clearing, and the previously-failing tool call now succeeding

## Notes for review

- Locale strings added for `en` and `zh-CN` only. `lint:i18n` already fails on `master` for unrelated pre-existing gaps, so I did not treat it as a gate.
- Keys for providers you stop using stay in the keychain. That's what makes switching back work, and they're now individually clearable, but there's no "forget all" action — happy to add one if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)