### PR TITLE
fix(ci): apply publishConfig overrides when publishing core packages

### DIFF
--- a/.github/workflows/core-release.yml
+++ b/.github/workflows/core-release.yml
@@ -43,7 +43,8 @@ jobs:
       run: |
         node <<'NODE'
         const { execFileSync } = require('node:child_process')
-        const { existsSync, readdirSync, readFileSync } = require('node:fs')
+        const { existsSync, mkdtempSync, readdirSync, readFileSync } = require('node:fs')
+        const { tmpdir } = require('node:os')
         const { join } = require('node:path')
 
         for (const entry of readdirSync('packages', { withFileTypes: true })) {
@@ -64,12 +65,28 @@ jobs:
               '--registry=https://registry.npmjs.org',
             ], { stdio: 'ignore' })
             console.log(`Skipping ${pkg.name}@${pkg.version}; it is already published.`)
+            continue
           } catch {
-            execFileSync('npm', ['publish', '--access=public', '--ignore-scripts'], {
-              cwd: directory,
-              stdio: 'inherit',
-            })
+            // Not on the registry yet, so fall through and publish it.
           }
+
+          // These packages point main/module/browser at index.ts for in-repo resolution and rely on
+          // publishConfig to swap in the dist/ paths. npm does not apply those overrides, so pack with
+          // pnpm (which does) and hand npm the finished tarball to keep trusted publishing.
+          const packDirectory = mkdtempSync(join(tmpdir(), 'xmcl-pack-'))
+          execFileSync('pnpm', ['pack', '--pack-destination', packDirectory], {
+            cwd: directory,
+            stdio: 'inherit',
+          })
+
+          const tarball = readdirSync(packDirectory).find(file => file.endsWith('.tgz'))
+          if (!tarball) {
+            throw new Error(`pnpm pack produced no tarball for ${pkg.name}`)
+          }
+
+          execFileSync('npm', ['publish', join(packDirectory, tarball), '--access=public', '--ignore-scripts'], {
+            stdio: 'inherit',
+          })
         }
         NODE
     - name: Build Docs

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -12,6 +12,11 @@
     "build:cjs": "esbuild --target=es2020 --platform=node --external:kysely --sourcemap --format=cjs --bundle --outfile=dist/index.js index.ts",
     "build:esm": "esbuild --target=es2020 --platform=node --external:kysely --sourcemap --format=esm --bundle --outfile=dist/index.mjs index.ts"
   },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "module": "./dist/index.mjs"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes #1643.

Since #1624 the core packages are published with `npm publish`, but npm doesn't apply `publishConfig` field overrides - that's a pnpm behaviour. Every package that points `main`/`module`/`browser` at index.ts and relies on `publishConfig` to swap in `dist/` paths therefore shipped TypeScript source as its entry point, which Node refuses to load (`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`).

This packs with `pnpm pack`, which applies the overrides, then hands the resulting tarball to `npm publish` so trusted publishing is preserved.

Also adds the missing `publishConfig` to `@xmcl/sqlite`, which builds CJS and ESM into `dist/` but never pointed at them.

Affected published versions include `@xmcl/core@2.16.0`, `@xmcl/installer@6.3.1`, `@xmcl/user@4.4.1`, `@xmcl/client@3.2.1`, `@xmcl/curseforge@2.2.1`, `@xmcl/modrinth@2.5.1` and others - each needs a patch re-publish after this lands.

