### PR TITLE
feat(ui): show active state on collection bookmark button

### DIFF
--- a/xmcl-keystone-ui/src/components/MarketProjectDetail.vue
+++ b/xmcl-keystone-ui/src/components/MarketProjectDetail.vue
@@ -52,14 +52,17 @@
             <template #activator="{ props: menu }">
               <v-btn
                 v-bind="menu"
-                variant="plain"
+                :variant="collection ? 'tonal' : 'plain'"
+                :color="collection ? 'primary' : undefined"
                 icon
                 :loading="loadingCollections"
                 size="small"
                 data-testid="market-detail-collection-menu"
                 :aria-label="t('localCollection.addToCollection')"
               >
-                <v-icon class="material-icons-outlined"> bookmark_add </v-icon>
+                <v-icon :class="collection ? '' : 'material-icons-outlined'">
+                  {{ collection ? 'bookmark' : 'bookmark_add' }}
+                </v-icon>
               </v-btn>
             </template>
             <v-card min-width="360" width="420" max-width="90vw" class="overflow-y-auto" style="max-height: 60vh">


### PR DESCRIPTION
## Problem

Closes #1659.

The bookmark button in the market detail panel showed the same `bookmark_add` (outlined) icon regardless of whether the project was already saved to a Modrinth collection. There was no visual feedback to distinguish "not in any collection" from "already in a collection".

## Solution

The `collection` prop already flows down to `MarketProjectDetail` with the collection ID when the current project belongs to one (via `useInCollection` → `collectionId`). This change uses that prop to conditionally style the button:

| State | Icon | Variant | Color |
|---|---|---|---|
| Not in any collection | `bookmark_add` (outlined) | `plain` | — |
| In a collection | `bookmark` (filled) | `tonal` | `primary` |

No new props, no new composables — purely reactive on existing data.

## Test plan

- [ ] Open a mod detail panel for a project **not** in any collection → button shows outlined `bookmark_add`, no highlight
- [ ] Add the project to a Modrinth collection → button immediately switches to filled `bookmark` with primary tonal background
- [ ] Remove it from the collection → button reverts to the outlined state

🤖 Generated with [Claude Code](https://claude.com/claude-code)