### PR TITLE
fix(mod): align CurseForge upgrade plan key with item.id

### DIFF
--- a/xmcl-keystone-ui/src/composables/modUpgrade.ts
+++ b/xmcl-keystone-ui/src/composables/modUpgrade.ts
@@ -116,9 +116,11 @@ export function useModUpgrade(
           const file = markRaw(candidates[0])
           const current = mod
           if (file.id !== current.curseforge?.fileId) {
-            // this is the new version
-            if (!result[mod.curseforge!.projectId]) {
-              result[mod.curseforge!.projectId] = {
+            // Key by modrinthId when available so it matches the item.id used by
+            // modSearch (which also prefers modrinthId over curseforgeId).
+            const planKey = mod.modrinth?.projectId ?? mod.curseforge!.projectId.toString()
+            if (!result[planKey]) {
+              result[planKey] = {
                 file,
                 mod,
                 updating: false,


### PR DESCRIPTION
## Problem

Closes #1671.

When the upgrade policy is set to **CurseForge** (or CurseForge-first), mods that have **both** a Modrinth and a CurseForge ID would pass through `checkCurseforgeUpgrade` first and their plan would be stored under `curseforge.projectId` (a numeric key, e.g. `306612`).

However, `modSearch.ts` derives `item.id` using the same priority as the UI expects:

```ts
// modSearch.ts — line 61
const id = modrinthId || curseforgeId?.toString() || name
```

So for a dual-provider mod, `item.id` is the **Modrinth project ID** (e.g. `"AANobbMI"`), while the upgrade plan lived at key `"306612"`. `plans[item.id]` was always `undefined`, causing:

- The update badge on the mod list item to never appear
- The new version not being listed in the mod detail panel

## Root cause

```
checkCurseforgeUpgrade:  result[mod.curseforge!.projectId] = plan  →  "306612"
modSearch item.id:       modrinthId || curseforgeId || name        →  "AANobbMI"
MarketBase hasUpdate:    !!plans[item.id]                          →  false  ❌
```

## Fix

Use the same key derivation in `checkCurseforgeUpgrade`: prefer `modrinthId` when the mod has one, fall back to `curseforgeId.toString()`.

```ts
const planKey = mod.modrinth?.projectId ?? mod.curseforge!.projectId.toString()
```

One-line change, no new dependencies, no behaviour change for mods that only have a CurseForge ID.

## Test plan

- [ ] Install a mod that is available on both Modrinth and CurseForge (e.g. JEI, Sodium)
- [ ] Set the upgrade policy to **CurseForge** or **CurseForge first**
- [ ] Click **Check for updates**
- [ ] Confirm the update badge appears on the mod list item
- [ ] Open the mod detail panel and confirm the new version is listed

🤖 Generated with [Claude Code](https://claude.com/claude-code)