### PR TITLE
fix(ui): scroll agent chat to bottom after conversation loads on open

### DIFF
--- a/xmcl-keystone-ui/src/views/AppAgentChat.vue
+++ b/xmcl-keystone-ui/src/views/AppAgentChat.vue
@@ -300,9 +300,9 @@ const scrollEl = ref<HTMLElement | null>(null)
 const followTranscript = ref(true)
 
 const pendingAgentKind = usePendingAgentKind()
-// Select the requested agent and (for the common agent) load its conversation
-// only on a fresh open, not while flipping tabs with the surface left open.
-watch(isShown, (visible, wasVisible) => {
+// Select the requested agent, load its conversation, then scroll to the latest
+// message — all in one watcher so the scroll happens after the async load.
+watch(isShown, async (visible, wasVisible) => {
   if (!visible || wasVisible) return
   const kind = pendingAgentKind.value
   pendingAgentKind.value = 'common'
@@ -310,8 +310,11 @@ watch(isShown, (visible, wasVisible) => {
     selectedAgent.value = 'css'
   } else {
     selectedAgent.value = 'common'
-    commonAgent.loadConversationForCurrentInstance()
+    await commonAgent.loadConversationForCurrentInstance()
   }
+  followTranscript.value = true
+  await nextTick()
+  scrollTranscriptToBottom()
 })
 
 const transcriptItems = computed(() => projectAgentTranscript(messages.value))
@@ -422,13 +425,6 @@ watch([transcriptItems, events, confirmationShown, displayError], async () => {
   if (followTranscript.value) scrollTranscriptToBottom()
 }, { deep: true })
 
-watch(isShown, async (v) => {
-  if (v) {
-    followTranscript.value = true
-    await nextTick()
-    scrollTranscriptToBottom()
-  }
-})
 </script>
 
 <style scoped>


### PR DESCRIPTION
Fixes #1691

## Root cause

`AppAgentChat.vue` had two separate `watch(isShown)` handlers that raced against each other:

1. **First watcher** — selected the agent and called `commonAgent.loadConversationForCurrentInstance()` **without `await`** (fire-and-forget).
2. **Second watcher** — set `followTranscript = true`, awaited `nextTick()`, then called `scrollTranscriptToBottom()`.

Because the load was not awaited, the scroll in the second watcher ran while the conversation fetch was still in-flight. `scrollHeight` reflected empty or stale content, so the panel opened mid-transcript instead of at the bottom.

## Fix

Merged the two `watch(isShown)` handlers into a single `async` watcher that:

1. Selects the agent (unchanged).
2. `await`s `loadConversationForCurrentInstance()` before continuing.
3. Sets `followTranscript = true`, waits for `nextTick()`, then scrolls — so `scrollHeight` is accurate by the time the scroll executes.

The `[transcriptItems, …]` watcher that follows live output is unchanged.

## Changed files

- `xmcl-keystone-ui/src/views/AppAgentChat.vue` — merged two `watch(isShown)` into one async watcher (7 insertions, 11 deletions).