### PR TITLE
fix: handle EXDEV in installer and atomic persistence

### DIFF
--- a/packages/installer/installManifest.exdev.test.ts
+++ b/packages/installer/installManifest.exdev.test.ts
@@ -1,0 +1,157 @@
+import { cp, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from 'fs/promises'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+import { createNodeInstallRuntime, executeInstallManifest, type InstallMaterializeOperation } from './installManifest'
+
+vi.mock('fs/promises', async (importOriginal) => {
+  const fs = await importOriginal<typeof import('fs/promises')>()
+  return { ...fs, rename: vi.fn(fs.rename), cp: vi.fn(fs.cp), rm: vi.fn(fs.rm) }
+})
+
+const realFs = await vi.importActual<typeof import('fs/promises')>('fs/promises')
+const exdev = Object.assign(new Error('cross-device link not permitted'), { code: 'EXDEV' })
+
+describe('materialization across virtualized volumes', () => {
+  let root: string
+  let target: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'xmcl-materialize-exdev-'))
+    target = join(root, 'MultiJarLauncher.class')
+    vi.mocked(rename).mockReset().mockRejectedValue(exdev)
+    vi.mocked(cp).mockReset().mockImplementation(realFs.cp)
+    vi.mocked(rm).mockReset().mockImplementation(realFs.rm)
+  })
+
+  afterEach(async () => {
+    await realFs.rm(root, { recursive: true, force: true })
+  })
+
+  function install(operations: InstallMaterializeOperation[], size = 3) {
+    return executeInstallManifest({
+      schemaVersion: 1,
+      tasks: [{
+        id: 'batch-launcher',
+        type: 'materialize',
+        operations,
+        outputs: [{ path: target, size }],
+      }],
+    }, createNodeInstallRuntime())
+  }
+
+  test('keeps rename as the normal path', async () => {
+    vi.mocked(rename).mockImplementation(realFs.rename)
+    await install([{ type: 'write', path: target, content: 'new' }])
+
+    expect(rename).toHaveBeenCalledOnce()
+    expect(cp).not.toHaveBeenCalled()
+    expect(await readFile(target, 'utf8')).toBe('new')
+    expect(await readdir(root)).toEqual(['MultiJarLauncher.class'])
+  })
+
+  test.each([false, true])('copies a staged file and removes all temporary paths (existing=%s)', async (existing) => {
+    if (existing) await writeFile(target, 'old')
+    await install([{ type: 'write', path: target, content: 'new' }])
+
+    expect(cp).toHaveBeenCalledTimes(existing ? 2 : 1)
+    expect(await readFile(target, 'utf8')).toBe('new')
+    expect(await readdir(root)).toEqual(['MultiJarLauncher.class'])
+  })
+
+  test('restores the old target if copied output fails validation', async () => {
+    await writeFile(target, 'original')
+    await expect(install([{ type: 'write', path: target, content: 'bad' }], 10)).rejects.toThrow('invalid output')
+
+    expect(await readFile(target, 'utf8')).toBe('original')
+    expect(await readdir(root)).toEqual(['MultiJarLauncher.class'])
+  })
+
+  test('backs up and restores directory contents without merging old files', async () => {
+    await mkdir(target)
+    await writeFile(join(target, 'original'), 'old')
+    const runtime = createNodeInstallRuntime()
+    const transaction = await runtime.materialize([{ type: 'remove', path: target }])
+    await expect(realFs.stat(target)).rejects.toMatchObject({ code: 'ENOENT' })
+    await transaction.rollback()
+
+    expect(await readFile(join(target, 'original'), 'utf8')).toBe('old')
+    expect(await readdir(root)).toEqual(['MultiJarLauncher.class'])
+  })
+
+  test.each(['backup', 'install'])('cleans an incomplete %s copy without losing the original', async (phase) => {
+    await writeFile(target, 'original')
+    const copyError = Object.assign(new Error('disk full'), { code: 'ENOSPC' })
+    vi.mocked(cp).mockImplementation(async (source, destination, options) => {
+      if (phase === 'backup' ? String(destination).includes('.backup-') : String(source).includes('.install-')) {
+        await writeFile(destination, 'partial')
+        throw copyError
+      }
+      await realFs.cp(source, destination, options)
+    })
+
+    await expect(install([{ type: 'write', path: target, content: 'new' }])).rejects.toBe(copyError)
+
+    expect(await readFile(target, 'utf8')).toBe('original')
+    expect(await readdir(root)).toEqual(['MultiJarLauncher.class'])
+  })
+
+  test('removes partial output when there was no previous target', async () => {
+    vi.mocked(cp).mockImplementation(async (_source, destination) => {
+      await writeFile(destination, 'partial')
+      throw Object.assign(new Error('disk full'), { code: 'ENOSPC' })
+    })
+
+    await expect(install([{ type: 'write', path: target, content: 'new' }])).rejects.toMatchObject({ code: 'ENOSPC' })
+    expect(await readdir(root)).toEqual([])
+  })
+
+  test('records the complete backup before attempting to remove its source', async () => {
+    await writeFile(target, 'original')
+    const removeError = Object.assign(new Error('file busy'), { code: 'EBUSY' })
+    vi.mocked(rm).mockRejectedValueOnce(removeError)
+
+    await expect(install([{ type: 'write', path: target, content: 'new' }])).rejects.toBe(removeError)
+
+    expect(await readFile(target, 'utf8')).toBe('original')
+    expect(await readdir(root)).toEqual(['MultiJarLauncher.class'])
+  })
+
+  test('rolls back if removing the staged source after copying fails', async () => {
+    await writeFile(target, 'original')
+    const removeError = Object.assign(new Error('file busy'), { code: 'EBUSY' })
+    vi.mocked(rm).mockImplementationOnce(realFs.rm).mockRejectedValueOnce(removeError)
+
+    await expect(install([{ type: 'write', path: target, content: 'new' }])).rejects.toBe(removeError)
+
+    expect(await readFile(target, 'utf8')).toBe('original')
+    expect(await readdir(root)).toEqual(['MultiJarLauncher.class'])
+  })
+
+  test('does not copy on unrelated rename errors', async () => {
+    await writeFile(target, 'original')
+    const error = Object.assign(new Error('access denied'), { code: 'EACCES' })
+    vi.mocked(rename).mockRejectedValue(error)
+
+    await expect(install([{ type: 'write', path: target, content: 'new' }])).rejects.toBe(error)
+
+    expect(cp).not.toHaveBeenCalled()
+    expect(await readFile(target, 'utf8')).toBe('original')
+    expect(await readdir(root)).toEqual(['MultiJarLauncher.class'])
+  })
+
+  test('reports rollback failure and retains the recoverable backup', async () => {
+    await writeFile(target, 'original')
+    vi.mocked(cp).mockImplementation(async (source, destination, options) => {
+      if (String(source).includes('.backup-')) throw new Error('cannot restore backup')
+      await realFs.cp(source, destination, options)
+    })
+
+    await expect(install([{ type: 'write', path: target, content: 'bad' }], 10)).rejects.toThrow('Failed to roll back materialization')
+
+    const files = await readdir(root)
+    expect(files).toHaveLength(1)
+    expect(files[0]).toContain('.backup-')
+    expect(await readFile(join(root, files[0]), 'utf8')).toBe('original')
+  })
+})

--- a/packages/installer/installManifest.ts
+++ b/packages/installer/installManifest.ts
@@ -1,7 +1,7 @@
 import { open, openEntryReadStream, readAllEntries, walkEntriesGenerator } from '@xmcl/unzip'
 import { spawn } from 'child_process'
 import { createReadStream, createWriteStream } from 'fs'
-import { chmod, copyFile, link, mkdir, readFile, rename, rm, stat, symlink, unlink, writeFile } from 'fs/promises'
+import { chmod, copyFile, link, mkdir, readFile, rm, stat, symlink, unlink, writeFile } from 'fs/promises'
 import { dirname, join, sep } from 'path'
 import { pipeline } from 'stream/promises'
 import { setTimeout as wait } from 'timers/promises'
@@ -9,6 +9,7 @@ import { extract } from 'tar-stream'
 import { createGunzip } from 'zlib'
 import { ZipFile as WriteableZipFile } from 'yazl'
 import { checksum as checksumFile, waitProcess } from './utils'
+import { move } from './move'
 
 export interface InstallFileChecksum {
   algorithm: string
@@ -287,7 +288,11 @@ async function executeMaterialize(task: InstallMaterializeTask, runtime: Install
     }
     await transaction.commit()
   } catch (error) {
-    await transaction.rollback()
+    try {
+      await transaction.rollback()
+    } catch (rollbackError) {
+      throw new AggregateError([error, rollbackError], 'Failed to roll back materialization', { cause: error })
+    }
     throw error
   }
 }
@@ -536,19 +541,31 @@ export function createNodeInstallRuntime(options: NodeInstallRuntimeOptions = {}
         created?: boolean
       }> = []
       const rollback = async () => {
+        const errors: unknown[] = []
         for (const entry of [...prepared].reverse()) {
-          if (entry.operation.type === 'ensure-directory') {
-            if (entry.created) await rm(entry.operation.path, { recursive: true, force: true }).catch(() => undefined)
-            continue
+          try {
+            if (entry.operation.type === 'ensure-directory') {
+              if (entry.created) await rm(entry.operation.path, { recursive: true, force: true })
+              continue
+            }
+            if (entry.replaced || entry.backup) {
+              await rm(entry.operation.path, { recursive: true, force: true })
+            }
+            if (entry.backup) {
+              await move(entry.backup, entry.operation.path)
+            }
+          } catch (error) {
+            errors.push(error)
           }
-          if (entry.replaced && entry.operation.type !== 'remove') {
-            await rm(entry.operation.path, { recursive: true, force: true }).catch(() => undefined)
+          if (entry.temporary) {
+            try {
+              await rm(entry.temporary, { recursive: true, force: true })
+            } catch (error) {
+              errors.push(error)
+            }
           }
-          if (entry.backup) {
-            await rename(entry.backup, entry.operation.path).catch(() => undefined)
-          }
-          if (entry.temporary) await rm(entry.temporary, { recursive: true, force: true }).catch(() => undefined)
         }
+        if (errors.length > 0) throw new AggregateError(errors, 'Failed to restore materialized paths')
       }
       try {
         for (const operation of operations) {
@@ -624,17 +641,20 @@ export function createNodeInstallRuntime(options: NodeInstallRuntimeOptions = {}
           if (entry.operation.type === 'ensure-directory') continue
           const backup = `${entry.operation.path}.backup-${process.pid}-${Math.random().toString(36).slice(2)}`
           if (await stat(entry.operation.path).then(() => true, () => false)) {
-            await rename(entry.operation.path, backup)
-            entry.backup = backup
-          }
-          if (entry.operation.type !== 'remove' && entry.temporary) {
-            await rename(entry.temporary, entry.operation.path)
-            entry.temporary = undefined
+            await move(entry.operation.path, backup, () => { entry.backup = backup })
           }
           entry.replaced = true
+          if (entry.operation.type !== 'remove' && entry.temporary) {
+            await move(entry.temporary, entry.operation.path)
+            entry.temporary = undefined
+          }
         }
       } catch (error) {
-        await rollback()
+        try {
+          await rollback()
+        } catch (rollbackError) {
+          throw new AggregateError([error, rollbackError], 'Failed to roll back materialization', { cause: error })
+        }
         throw error
       }
 

--- a/packages/installer/move.ts
+++ b/packages/installer/move.ts
@@ -1,0 +1,36 @@
+import { cp, rename, rm } from 'fs/promises'
+
+/**
+ * Move to a vacant transaction path. AppX virtualization can make even sibling
+ * paths cross volumes, so the fallback is deliberately not atomic.
+ */
+export async function move(source: string, destination: string, onMoved?: () => void) {
+  try {
+    await rename(source, destination)
+  } catch (error) {
+    if (!error || typeof error !== 'object' || !('code' in error) || error.code !== 'EXDEV') throw error
+    try {
+      await cp(source, destination, {
+        recursive: true,
+        force: false,
+        errorOnExist: true,
+        preserveTimestamps: true,
+        verbatimSymlinks: true,
+      })
+    } catch (copyError) {
+      if (!copyError || typeof copyError !== 'object' || !('code' in copyError) || copyError.code !== 'EEXIST') {
+        try {
+          await rm(destination, { recursive: true, force: true })
+        } catch (cleanupError) {
+          throw new AggregateError([copyError, cleanupError], `Failed to clean up incomplete copy to ${destination}`)
+        }
+      }
+      throw copyError
+    }
+    // Register the complete backup before deleting its source, which can fail.
+    onMoved?.()
+    await rm(source, { recursive: true })
+    return
+  }
+  onMoved?.()
+}

--- a/patches/atomically@2.0.3.patch
+++ b/patches/atomically@2.0.3.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/index.js b/dist/index.js
-index afec4cab0f79c6472484f8a601cb692be3a6e0e3..78dee6523ad40b67beb0c18bcb3b032db3629e1e 100644
+index afec4cab0f79c6472484f8a601cb692be3a6e0e3..a649fcc4fece9864445afbc1ca80e71418fdbd02 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -1,5 +1,6 @@
@@ -9,7 +9,7 @@ index afec4cab0f79c6472484f8a601cb692be3a6e0e3..78dee6523ad40b67beb0c18bcb3b032d
  import fs from 'stubborn-fs';
  import { DEFAULT_ENCODING, DEFAULT_FILE_MODE, DEFAULT_FOLDER_MODE, DEFAULT_READ_OPTIONS, DEFAULT_WRITE_OPTIONS, DEFAULT_USER_UID, DEFAULT_USER_GID, DEFAULT_TIMEOUT_ASYNC, DEFAULT_TIMEOUT_SYNC, IS_POSIX } from './constants.js';
  import { isException, isFunction, isString, isUndefined } from './utils/lang.js';
-@@ -95,9 +96,29 @@ async function writeFileAsync(filePath, data, options = DEFAULT_WRITE_OPTIONS) {
+@@ -95,9 +96,62 @@ async function writeFileAsync(filePath, data, options = DEFAULT_WRITE_OPTIONS) {
          catch (error) {
              if (!isException(error))
                  throw error;
@@ -17,17 +17,50 @@ index afec4cab0f79c6472484f8a601cb692be3a6e0e3..78dee6523ad40b67beb0c18bcb3b032d
 +            // AppX virtualization can redirect even sibling paths across volumes.
 +            // Copying is not atomic, but keeps the completed write and scheduler lock.
 +            if (error.code === 'EXDEV') {
-+                await nativeFs.promises.copyFile(tempPath, filePath);
-+                if (options.fsync !== false) {
-+                    fd = await fs.retry.open(timeout)(filePath, 'r+');
-+                    if (options.fsyncWait !== false) {
-+                        await fs.retry.fsync(timeout)(fd);
++                const [backupPath, disposeBackup] = filePathExists
++                    ? Temp.get(filePath, Temp.create, false)
++                    : [null, () => {}];
++                let replacing = false;
++                let preserveBackup = false;
++                try {
++                    if (backupPath) {
++                        await nativeFs.promises.copyFile(filePath, backupPath);
++                        await syncCopy(backupPath, options, timeout);
 +                    }
-+                    else {
-+                        fs.attempt.fsync(fd);
++                    replacing = true;
++                    await nativeFs.promises.copyFile(tempPath, filePath);
++                    await syncCopy(filePath, options, timeout);
++                }
++                catch (copyError) {
++                    if (replacing) {
++                        try {
++                            if (backupPath) {
++                                await nativeFs.promises.copyFile(backupPath, filePath);
++                                await syncCopy(filePath, options, timeout);
++                            }
++                            else {
++                                await nativeFs.promises.rm(filePath, { force: true });
++                            }
++                        }
++                        catch (restoreError) {
++                            preserveBackup = true;
++                            const recoveryError = Object.assign(
++                                new AggregateError([copyError, restoreError], `Failed to restore ${filePath}`, { cause: copyError }),
++                                { backupPath, temporaryPath: tempPath },
++                            );
++                            // Keep both complete versions available for manual recovery.
++                            tempDisposer();
++                            tempPath = null;
++                            throw recoveryError;
++                        }
 +                    }
-+                    await fs.retry.close(timeout)(fd);
-+                    fd = null;
++                    throw copyError;
++                }
++                finally {
++                    disposeBackup();
++                    if (backupPath && !preserveBackup) {
++                        await nativeFs.promises.rm(backupPath, { force: true });
++                    }
 +                }
 +                await nativeFs.promises.unlink(tempPath);
 +            }
@@ -41,23 +74,55 @@ index afec4cab0f79c6472484f8a601cb692be3a6e0e3..78dee6523ad40b67beb0c18bcb3b032d
          }
          tempDisposer();
          tempPath = null;
-@@ -178,9 +199,27 @@ function writeFileSync(filePath, data, options = DEFAULT_WRITE_OPTIONS) {
+@@ -178,9 +232,59 @@ function writeFileSync(filePath, data, options = DEFAULT_WRITE_OPTIONS) {
          catch (error) {
              if (!isException(error))
                  throw error;
 -            if (error.code !== 'ENAMETOOLONG')
 +            if (error.code === 'EXDEV') {
-+                nativeFs.copyFileSync(tempPath, filePath);
-+                if (options.fsync !== false) {
-+                    fd = fs.retry.openSync(timeout)(filePath, 'r+');
-+                    if (options.fsyncWait !== false) {
-+                        fs.retry.fsyncSync(timeout)(fd);
++                const [backupPath, disposeBackup] = filePathExists
++                    ? Temp.get(filePath, Temp.create, false)
++                    : [null, () => {}];
++                let replacing = false;
++                let preserveBackup = false;
++                try {
++                    if (backupPath) {
++                        nativeFs.copyFileSync(filePath, backupPath);
++                        syncCopySync(backupPath, options, timeout);
 +                    }
-+                    else {
-+                        fs.attempt.fsyncSync(fd);
++                    replacing = true;
++                    nativeFs.copyFileSync(tempPath, filePath);
++                    syncCopySync(filePath, options, timeout);
++                }
++                catch (copyError) {
++                    if (replacing) {
++                        try {
++                            if (backupPath) {
++                                nativeFs.copyFileSync(backupPath, filePath);
++                                syncCopySync(filePath, options, timeout);
++                            }
++                            else {
++                                nativeFs.rmSync(filePath, { force: true });
++                            }
++                        }
++                        catch (restoreError) {
++                            preserveBackup = true;
++                            const recoveryError = Object.assign(
++                                new AggregateError([copyError, restoreError], `Failed to restore ${filePath}`, { cause: copyError }),
++                                { backupPath, temporaryPath: tempPath },
++                            );
++                            tempDisposer();
++                            tempPath = null;
++                            throw recoveryError;
++                        }
 +                    }
-+                    fs.retry.closeSync(timeout)(fd);
-+                    fd = null;
++                    throw copyError;
++                }
++                finally {
++                    disposeBackup();
++                    if (backupPath && !preserveBackup) {
++                        nativeFs.rmSync(backupPath, { force: true });
++                    }
 +                }
 +                nativeFs.unlinkSync(tempPath);
 +            }
@@ -71,3 +136,41 @@ index afec4cab0f79c6472484f8a601cb692be3a6e0e3..78dee6523ad40b67beb0c18bcb3b032d
          }
          tempDisposer();
          tempPath = null;
+@@ -192,5 +296,37 @@ function writeFileSync(filePath, data, options = DEFAULT_WRITE_OPTIONS) {
+             Temp.purge(tempPath);
+     }
+ }
++async function syncCopy(filePath, options, timeout) {
++    if (options.fsync === false)
++        return;
++    const fd = await fs.retry.open(timeout)(filePath, 'r+');
++    try {
++        if (options.fsyncWait !== false) {
++            await fs.retry.fsync(timeout)(fd);
++        }
++        else {
++            fs.attempt.fsync(fd);
++        }
++    }
++    finally {
++        await fs.retry.close(timeout)(fd);
++    }
++}
++function syncCopySync(filePath, options, timeout) {
++    if (options.fsync === false)
++        return;
++    const fd = fs.retry.openSync(timeout)(filePath, 'r+');
++    try {
++        if (options.fsyncWait !== false) {
++            fs.retry.fsyncSync(timeout)(fd);
++        }
++        else {
++            fs.attempt.fsyncSync(fd);
++        }
++    }
++    finally {
++        fs.retry.closeSync(timeout)(fd);
++    }
++}
+ /* EXPORT */
+ export { readFile, readFileSync, writeFile, writeFileSync };

--- a/patches/atomically@2.0.3.patch
+++ b/patches/atomically@2.0.3.patch
@@ -1,0 +1,73 @@
+diff --git a/dist/index.js b/dist/index.js
+index afec4cab0f79c6472484f8a601cb692be3a6e0e3..78dee6523ad40b67beb0c18bcb3b032db3629e1e 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1,5 +1,6 @@
+ /* IMPORT */
+ import path from 'node:path';
++import nativeFs from 'node:fs';
+ import fs from 'stubborn-fs';
+ import { DEFAULT_ENCODING, DEFAULT_FILE_MODE, DEFAULT_FOLDER_MODE, DEFAULT_READ_OPTIONS, DEFAULT_WRITE_OPTIONS, DEFAULT_USER_UID, DEFAULT_USER_GID, DEFAULT_TIMEOUT_ASYNC, DEFAULT_TIMEOUT_SYNC, IS_POSIX } from './constants.js';
+ import { isException, isFunction, isString, isUndefined } from './utils/lang.js';
+@@ -95,9 +96,29 @@ async function writeFileAsync(filePath, data, options = DEFAULT_WRITE_OPTIONS) {
+         catch (error) {
+             if (!isException(error))
+                 throw error;
+-            if (error.code !== 'ENAMETOOLONG')
++            // AppX virtualization can redirect even sibling paths across volumes.
++            // Copying is not atomic, but keeps the completed write and scheduler lock.
++            if (error.code === 'EXDEV') {
++                await nativeFs.promises.copyFile(tempPath, filePath);
++                if (options.fsync !== false) {
++                    fd = await fs.retry.open(timeout)(filePath, 'r+');
++                    if (options.fsyncWait !== false) {
++                        await fs.retry.fsync(timeout)(fd);
++                    }
++                    else {
++                        fs.attempt.fsync(fd);
++                    }
++                    await fs.retry.close(timeout)(fd);
++                    fd = null;
++                }
++                await nativeFs.promises.unlink(tempPath);
++            }
++            else if (error.code === 'ENAMETOOLONG') {
++                await fs.retry.rename(timeout)(tempPath, Temp.truncate(filePath));
++            }
++            else {
+                 throw error;
+-            await fs.retry.rename(timeout)(tempPath, Temp.truncate(filePath));
++            }
+         }
+         tempDisposer();
+         tempPath = null;
+@@ -178,9 +199,27 @@ function writeFileSync(filePath, data, options = DEFAULT_WRITE_OPTIONS) {
+         catch (error) {
+             if (!isException(error))
+                 throw error;
+-            if (error.code !== 'ENAMETOOLONG')
++            if (error.code === 'EXDEV') {
++                nativeFs.copyFileSync(tempPath, filePath);
++                if (options.fsync !== false) {
++                    fd = fs.retry.openSync(timeout)(filePath, 'r+');
++                    if (options.fsyncWait !== false) {
++                        fs.retry.fsyncSync(timeout)(fd);
++                    }
++                    else {
++                        fs.attempt.fsyncSync(fd);
++                    }
++                    fs.retry.closeSync(timeout)(fd);
++                    fd = null;
++                }
++                nativeFs.unlinkSync(tempPath);
++            }
++            else if (error.code === 'ENAMETOOLONG') {
++                fs.retry.renameSync(timeout)(tempPath, Temp.truncate(filePath));
++            }
++            else {
+                 throw error;
+-            fs.retry.renameSync(timeout)(tempPath, Temp.truncate(filePath));
++            }
+         }
+         tempDisposer();
+         tempPath = null;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,7 +41,7 @@ overrides:
 packageExtensionsChecksum: sha256-W6XTOoW6VEuHfMMNvfHK+GqTlJq4359UxTUPBI9HzXw=
 
 patchedDependencies:
-  atomically@2.0.3: a5059e26f5cd3c544ce42ebbd278c1e4163e7c3acada3be09bdf28ca78f0a4c5
+  atomically@2.0.3: 9dfad98db64061412c4e6b4560fb93f3905edefc411028a115e36ef4258b126b
 
 importers:
 
@@ -1460,7 +1460,7 @@ importers:
         version: 0.5.0
       atomically:
         specifier: ^2.0.3
-        version: 2.0.3(patch_hash=a5059e26f5cd3c544ce42ebbd278c1e4163e7c3acada3be09bdf28ca78f0a4c5)
+        version: 2.0.3(patch_hash=9dfad98db64061412c4e6b4560fb93f3905edefc411028a115e36ef4258b126b)
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -8577,7 +8577,7 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  atomically@2.0.3(patch_hash=a5059e26f5cd3c544ce42ebbd278c1e4163e7c3acada3be09bdf28ca78f0a4c5):
+  atomically@2.0.3(patch_hash=9dfad98db64061412c4e6b4560fb93f3905edefc411028a115e36ef4258b126b):
     dependencies:
       stubborn-fs: 1.2.5
       when-exit: 2.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,9 @@ overrides:
 
 packageExtensionsChecksum: sha256-W6XTOoW6VEuHfMMNvfHK+GqTlJq4359UxTUPBI9HzXw=
 
+patchedDependencies:
+  atomically@2.0.3: a5059e26f5cd3c544ce42ebbd278c1e4163e7c3acada3be09bdf28ca78f0a4c5
+
 importers:
 
   .:
@@ -1457,7 +1460,7 @@ importers:
         version: 0.5.0
       atomically:
         specifier: ^2.0.3
-        version: 2.0.3
+        version: 2.0.3(patch_hash=a5059e26f5cd3c544ce42ebbd278c1e4163e7c3acada3be09bdf28ca78f0a4c5)
       chokidar:
         specifier: ^4.0.3
         version: 4.0.3
@@ -8574,7 +8577,7 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
-  atomically@2.0.3:
+  atomically@2.0.3(patch_hash=a5059e26f5cd3c544ce42ebbd278c1e4163e7c3acada3be09bdf28ca78f0a4c5):
     dependencies:
       stubborn-fs: 1.2.5
       when-exit: 2.1.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,3 +69,6 @@ packageExtensions:
   cls-hooked:
     dependencies:
       stack-chain: '^1.3.7'
+
+patchedDependencies:
+  atomically@2.0.3: patches/atomically@2.0.3.patch

--- a/xmcl-runtime/util/atomicWrite.test.ts
+++ b/xmcl-runtime/util/atomicWrite.test.ts
@@ -16,6 +16,8 @@ const script = `
 import fs from 'node:fs'
 const options = JSON.parse(process.argv[1])
 const events = []
+let targetCopies = 0
+let syncs = 0
 const failure = code => Object.assign(new Error(code), { code })
 const rename = fs.rename
 const renameSync = fs.renameSync
@@ -33,22 +35,44 @@ const copy = fs.promises.copyFile
 const copySync = fs.copyFileSync
 fs.promises.copyFile = async (...args) => {
   events.push('copy')
-  if (options.copyError) throw failure(options.copyError)
+  if (args[1] === options.target) {
+    targetCopies += 1
+    if (targetCopies === 1 && options.copyError) {
+      if (options.partialCopy) await fs.promises.writeFile(args[1], 'partial')
+      throw failure(options.copyError)
+    }
+    if (targetCopies > 1 && options.restoreError) throw failure(options.restoreError)
+  } else if (options.backupError) {
+    await fs.promises.writeFile(args[1], 'partial backup')
+    throw failure(options.backupError)
+  }
   await copy(...args)
 }
 fs.copyFileSync = (...args) => {
   events.push('copy')
-  if (options.copyError) throw failure(options.copyError)
+  if (args[1] === options.target) {
+    targetCopies += 1
+    if (targetCopies === 1 && options.copyError) {
+      if (options.partialCopy) fs.writeFileSync(args[1], 'partial')
+      throw failure(options.copyError)
+    }
+    if (targetCopies > 1 && options.restoreError) throw failure(options.restoreError)
+  } else if (options.backupError) {
+    fs.writeFileSync(args[1], 'partial backup')
+    throw failure(options.backupError)
+  }
   return copySync(...args)
 }
 const fsync = fs.fsync
 const fsyncSync = fs.fsyncSync
 fs.fsync = (fd, callback) => {
   events.push('fsync')
+  if (++syncs === options.fsyncErrorOn) return callback(failure('ENOSPC'))
   fsync(fd, callback)
 }
 fs.fsyncSync = fd => {
   events.push('fsync')
+  if (++syncs === options.fsyncErrorOn) throw failure('ENOSPC')
   return fsyncSync(fd)
 }
 const unlink = fs.promises.unlink
@@ -72,7 +96,11 @@ try {
   }
   console.log(JSON.stringify({ events }))
 } catch (error) {
-  console.log(JSON.stringify({ code: error.code, events }))
+  console.log(JSON.stringify({
+    code: error.code, events, message: error.message,
+    backupPath: error.backupPath, temporaryPath: error.temporaryPath,
+    errors: error.errors?.map(error => error.code),
+  }))
 }
 `
 
@@ -91,9 +119,20 @@ describe('atomically EXDEV dependency patch', () => {
     sync?: boolean
     code?: string
     copyError?: string
+    partialCopy?: boolean
+    backupError?: string
+    restoreError?: string
+    fsyncErrorOn?: number
     fsync?: boolean
     contents?: string[]
-  }): Promise<{ code?: string; events: string[] }> {
+  }): Promise<{
+    code?: string
+    message?: string
+    events: string[]
+    backupPath?: string
+    temporaryPath?: string
+    errors?: string[]
+  }> {
     const { stdout } = await exec(process.execPath, [
       '--input-type=module',
       '-e',
@@ -118,7 +157,9 @@ describe('atomically EXDEV dependency patch', () => {
       const result = await run({ sync, code: 'EXDEV' })
 
       expect(result.code).toBeUndefined()
-      expect(result.events).toEqual(['fsync', 'rename', 'copy', 'fsync', 'unlink'])
+      expect(result.events).toEqual(existing
+        ? ['fsync', 'rename', 'copy', 'fsync', 'copy', 'fsync', 'unlink']
+        : ['fsync', 'rename', 'copy', 'fsync', 'unlink'])
       expect(await readFile(target, 'utf8')).toBe('new')
       expect(await readdir(root)).toEqual(['index.json'])
     })
@@ -150,6 +191,52 @@ describe('atomically EXDEV dependency patch', () => {
       expect(await readFile(target, 'utf8')).toBe('original')
       expect(await readdir(root)).toEqual(['index.json'])
     })
+
+    test.each([false, true])('recovers after a copy partially overwrites the destination (existing=%s)', async (existing) => {
+      if (existing) await writeFile(target, 'original')
+      const result = await run({ sync, code: 'EXDEV', copyError: 'ENOSPC', partialCopy: true })
+
+      expect(result.code).toBe('ENOSPC')
+      if (existing) {
+        expect(await readFile(target, 'utf8')).toBe('original')
+        expect(await readdir(root)).toEqual(['index.json'])
+      } else {
+        expect(await readdir(root)).toEqual([])
+      }
+    })
+
+    test('does not overwrite the original when preparing its backup fails', async () => {
+      await writeFile(target, 'original')
+      const result = await run({ sync, code: 'EXDEV', backupError: 'ENOSPC' })
+
+      expect(result.code).toBe('ENOSPC')
+      expect(await readFile(target, 'utf8')).toBe('original')
+      expect(await readdir(root)).toEqual(['index.json'])
+    })
+
+    test('restores the original when syncing the new destination fails', async () => {
+      await writeFile(target, 'original')
+      const result = await run({ sync, code: 'EXDEV', fsyncErrorOn: 3 })
+
+      expect(result.code).toBe('ENOSPC')
+      expect(await readFile(target, 'utf8')).toBe('original')
+      expect(await readdir(root)).toEqual(['index.json'])
+    })
+
+    test('retains both complete recovery files if restoration also fails', async () => {
+      await writeFile(target, 'original')
+      const result = await run({
+        sync, code: 'EXDEV', copyError: 'ENOSPC', partialCopy: true, restoreError: 'EACCES',
+      })
+
+      expect(result.message).toContain('Failed to restore')
+      expect(result.errors).toEqual(['ENOSPC', 'EACCES'])
+      expect(result.backupPath).toBeDefined()
+      expect(result.temporaryPath).toBeDefined()
+      expect(await readFile(result.backupPath!, 'utf8')).toBe('original')
+      expect(await readFile(result.temporaryPath!, 'utf8')).toBe('new')
+      expect(await readdir(root)).toHaveLength(3)
+    })
   })
 
   test('keeps concurrent writes serialized through the complete fallback', async () => {
@@ -158,7 +245,7 @@ describe('atomically EXDEV dependency patch', () => {
     expect(result.code).toBeUndefined()
     expect(result.events).toEqual([
       'fsync', 'rename', 'copy', 'fsync', 'unlink',
-      'fsync', 'rename', 'copy', 'fsync', 'unlink',
+      'fsync', 'rename', 'copy', 'fsync', 'copy', 'fsync', 'unlink',
     ])
     expect(await readFile(target, 'utf8')).toBe('second')
     expect(await readdir(root)).toEqual(['index.json'])

--- a/xmcl-runtime/util/atomicWrite.test.ts
+++ b/xmcl-runtime/util/atomicWrite.test.ts
@@ -18,6 +18,7 @@ const options = JSON.parse(process.argv[1])
 const events = []
 let targetCopies = 0
 let syncs = 0
+let stagedPath
 const failure = code => Object.assign(new Error(code), { code })
 const rename = fs.rename
 const renameSync = fs.renameSync
@@ -78,16 +79,17 @@ fs.fsyncSync = fd => {
 const unlink = fs.promises.unlink
 const unlinkSync = fs.unlinkSync
 fs.promises.unlink = async path => {
-  events.push('unlink')
+  if (path === stagedPath) events.push('unlink')
   await unlink(path)
 }
 fs.unlinkSync = path => {
-  events.push('unlink')
+  // rmSync can also call unlinkSync internally when cleaning backups on POSIX.
+  if (path === stagedPath) events.push('unlink')
   return unlinkSync(path)
 }
 const atomic = await import(options.module)
 try {
-  const writeOptions = { timeout: 1, fsync: options.fsync }
+  const writeOptions = { timeout: 1, fsync: options.fsync, tmpCreated: path => { stagedPath = path } }
   if (options.sync) {
     atomic.writeFileSync(options.target, 'new', writeOptions)
   } else {

--- a/xmcl-runtime/util/atomicWrite.test.ts
+++ b/xmcl-runtime/util/atomicWrite.test.ts
@@ -1,0 +1,166 @@
+import { execFile } from 'child_process'
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'fs/promises'
+import { createRequire } from 'module'
+import { tmpdir } from 'os'
+import { join } from 'path'
+import { pathToFileURL } from 'url'
+import { promisify } from 'util'
+import { afterEach, beforeEach, describe, expect, test } from 'vitest'
+
+const exec = promisify(execFile)
+const atomicModule = pathToFileURL(createRequire(import.meta.url).resolve('atomically')).href
+
+// A fresh process lets stubborn-fs capture the fault-injected Node functions
+// without mocking atomically itself or modifying Vitest's filesystem.
+const script = `
+import fs from 'node:fs'
+const options = JSON.parse(process.argv[1])
+const events = []
+const failure = code => Object.assign(new Error(code), { code })
+const rename = fs.rename
+const renameSync = fs.renameSync
+fs.rename = (source, destination, callback) => {
+  events.push('rename')
+  if (options.code) callback(failure(options.code))
+  else rename(source, destination, callback)
+}
+fs.renameSync = (source, destination) => {
+  events.push('rename')
+  if (options.code) throw failure(options.code)
+  return renameSync(source, destination)
+}
+const copy = fs.promises.copyFile
+const copySync = fs.copyFileSync
+fs.promises.copyFile = async (...args) => {
+  events.push('copy')
+  if (options.copyError) throw failure(options.copyError)
+  await copy(...args)
+}
+fs.copyFileSync = (...args) => {
+  events.push('copy')
+  if (options.copyError) throw failure(options.copyError)
+  return copySync(...args)
+}
+const fsync = fs.fsync
+const fsyncSync = fs.fsyncSync
+fs.fsync = (fd, callback) => {
+  events.push('fsync')
+  fsync(fd, callback)
+}
+fs.fsyncSync = fd => {
+  events.push('fsync')
+  return fsyncSync(fd)
+}
+const unlink = fs.promises.unlink
+const unlinkSync = fs.unlinkSync
+fs.promises.unlink = async path => {
+  events.push('unlink')
+  await unlink(path)
+}
+fs.unlinkSync = path => {
+  events.push('unlink')
+  return unlinkSync(path)
+}
+const atomic = await import(options.module)
+try {
+  const writeOptions = { timeout: 1, fsync: options.fsync }
+  if (options.sync) {
+    atomic.writeFileSync(options.target, 'new', writeOptions)
+  } else {
+    await Promise.all((options.contents || ['new']).map(content =>
+      atomic.writeFile(options.target, content, writeOptions)))
+  }
+  console.log(JSON.stringify({ events }))
+} catch (error) {
+  console.log(JSON.stringify({ code: error.code, events }))
+}
+`
+
+describe('atomically EXDEV dependency patch', () => {
+  let root: string
+  let target: string
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'xmcl-atomic-exdev-'))
+    target = join(root, 'index.json')
+  })
+
+  afterEach(() => rm(root, { recursive: true, force: true }))
+
+  async function run(options: {
+    sync?: boolean
+    code?: string
+    copyError?: string
+    fsync?: boolean
+    contents?: string[]
+  }): Promise<{ code?: string; events: string[] }> {
+    const { stdout } = await exec(process.execPath, [
+      '--input-type=module',
+      '-e',
+      script,
+      JSON.stringify({ module: atomicModule, target, ...options }),
+    ])
+    return JSON.parse(stdout)
+  }
+
+  describe.each([false, true])('sync=%s', (sync) => {
+    test('uses rename without copying when it succeeds', async () => {
+      const result = await run({ sync })
+
+      expect(result.code).toBeUndefined()
+      expect(result.events).toEqual(['fsync', 'rename'])
+      expect(await readFile(target, 'utf8')).toBe('new')
+      expect(await readdir(root)).toEqual(['index.json'])
+    })
+
+    test.each([false, true])('copies and syncs the destination on EXDEV (existing=%s)', async (existing) => {
+      if (existing) await writeFile(target, 'original')
+      const result = await run({ sync, code: 'EXDEV' })
+
+      expect(result.code).toBeUndefined()
+      expect(result.events).toEqual(['fsync', 'rename', 'copy', 'fsync', 'unlink'])
+      expect(await readFile(target, 'utf8')).toBe('new')
+      expect(await readdir(root)).toEqual(['index.json'])
+    })
+
+    test('honors disabled fsync in the copy fallback', async () => {
+      const result = await run({ sync, code: 'EXDEV', fsync: false })
+
+      expect(result.code).toBeUndefined()
+      expect(result.events).toEqual(['rename', 'copy', 'unlink'])
+      expect(await readFile(target, 'utf8')).toBe('new')
+    })
+
+    test('propagates unrelated rename errors without copying', async () => {
+      await writeFile(target, 'original')
+      const result = await run({ sync, code: 'EINVAL' })
+
+      expect(result.code).toBe('EINVAL')
+      expect(result.events).not.toContain('copy')
+      expect(await readFile(target, 'utf8')).toBe('original')
+      expect(await readdir(root)).toEqual(['index.json'])
+    })
+
+    test('propagates copy failures and cleans the temporary file', async () => {
+      await writeFile(target, 'original')
+      const result = await run({ sync, code: 'EXDEV', copyError: 'ENOSPC' })
+
+      expect(result.code).toBe('ENOSPC')
+      expect(result.events).toContain('copy')
+      expect(await readFile(target, 'utf8')).toBe('original')
+      expect(await readdir(root)).toEqual(['index.json'])
+    })
+  })
+
+  test('keeps concurrent writes serialized through the complete fallback', async () => {
+    const result = await run({ code: 'EXDEV', contents: ['first', 'second'] })
+
+    expect(result.code).toBeUndefined()
+    expect(result.events).toEqual([
+      'fsync', 'rename', 'copy', 'fsync', 'unlink',
+      'fsync', 'rename', 'copy', 'fsync', 'unlink',
+    ])
+    expect(await readFile(target, 'utf8')).toBe('second')
+    expect(await readdir(root)).toEqual(['index.json'])
+  })
+})


### PR DESCRIPTION
## Summary

- Keep `rename` as the normal installer transaction path; on `EXDEV` only, copy the complete file or directory before removing its source.
- Apply the same fallback to installation backups and rollback. Clean incomplete copies, register a completed backup before source removal, and report rollback errors without discarding recoverable backups.
- Add an approved package-local `atomically@2.0.3` patch for asynchronous and synchronous writes. This covers skin lists, launch history, account persistence, and other existing atomic-write consumers while retaining scheduling, normal rename retries, and fsync.
- Before overwriting an existing persistence file, copy and sync a recovery backup. Restore it after a partial copy or destination-fsync failure; if restoration also fails, retain both complete recovery files and report their paths rather than purging them.

## Motivation and limitations

A Windows 11 / XMCL 0.68.1 AppX report contains repeated `EXDEV` errors renaming sibling paths under AppData, including `MultiJarLauncher.class`, skin metadata, and launch history. The executable resolves under a different drive's `WindowsApps` directory. AppX filesystem virtualization is a plausible cause, but the report does not prove the underlying volume mapping and we cannot reproduce that packaging-specific condition in the ordinary development app.

The fallback is intentionally limited to `EXDEV`. Copying across volumes is **not atomic**; unrelated filesystem errors still fail instead of silently switching strategies. Both installer and persistence fallbacks preserve recoverable data on copy failures. A failed restoration exposes explicit recovery paths.

## Validation

- 89 targeted tests passed across installer transactions/workflows and persistence, including 23 atomic-write fault-injection tests.
- Coverage includes ordinary rename, same-directory EXDEV, new/replaced files, directory backup/restore, partial copies, source removal failures, invalid outputs, failed rollback, async/sync persistence, fsync, and concurrent writes.
- Persistence tests fail copies **after modifying the destination**, and verify that recovery files survive process exit when restoration fails. POSIX backup-cleanup instrumentation was corrected in fc2b931de.
- Runtime type-check and scoped TypeScript lint passed. All five applicable checks on final head fc2b931de passed: Validate, Core Pull Request Test, and safety-net on Windows/macOS/Ubuntu. Showcase and packaged-boot are intentionally skipped by the workflow.
- Independent review found the initial partial-copy recovery gap; it is fixed and the finding is closed.
- Real development launcher at `localhost:3000`: Forge 1.20.1/47.3.0 installed in 96.2s (3,728 files), including MultiJarLauncher materialization, Java processors, cleanup, and clean diagnosis. Skin add/edit/delete and launch-history persistence survived restart.
- Final corrected-bundle smoke (built 20:06:45) exercised skin add/update/PNG serving/restart/delete/restart through real renderer/preload/main IPC. No renderer warnings/errors; pre-existing tray/initialization messages remained in main logs. Isolated resources and owned development processes were removed.
- Actual MSIX EXDEV was not reproduced locally. History used the existing no-Java hook, which emitted its known launch-ID warning; no real Minecraft process was launched.